### PR TITLE
organize how the TCK is layed out

### DIFF
--- a/tck/src/main/java/org/eclipse/microprofile/graphql/tck/annotations/argument/package-info.java
+++ b/tck/src/main/java/org/eclipse/microprofile/graphql/tck/annotations/argument/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2019 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ /*
+  * This package is for testing the @Argument annotation
+  */
+package org.eclipse.microprofile.graphql.tck.annotations.argument;

--- a/tck/src/main/java/org/eclipse/microprofile/graphql/tck/annotations/context/package-info.java
+++ b/tck/src/main/java/org/eclipse/microprofile/graphql/tck/annotations/context/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2019 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ /*
+  * This package is for testing the @Context annotation
+  */
+package org.eclipse.microprofile.graphql.tck.annotations.context;

--- a/tck/src/main/java/org/eclipse/microprofile/graphql/tck/annotations/enum/package-info.java
+++ b/tck/src/main/java/org/eclipse/microprofile/graphql/tck/annotations/enum/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2019 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ /*
+  * This package is for testing the @Enum annotation
+  */
+package org.eclipse.microprofile.graphql.tck.annotations.enum;

--- a/tck/src/main/java/org/eclipse/microprofile/graphql/tck/annotations/fieldorder/package-info.java
+++ b/tck/src/main/java/org/eclipse/microprofile/graphql/tck/annotations/fieldorder/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2019 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ /*
+  * This package is for testing the @FieldOrder annotation
+  */
+package org.eclipse.microprofile.graphql.tck.annotations.fieldorder;

--- a/tck/src/main/java/org/eclipse/microprofile/graphql/tck/annotations/ignore/package-info.java
+++ b/tck/src/main/java/org/eclipse/microprofile/graphql/tck/annotations/ignore/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2019 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ /*
+  * This package is for testing the @Ignore annotation
+  */
+package org.eclipse.microprofile.graphql.tck.annotations.ignore;

--- a/tck/src/main/java/org/eclipse/microprofile/graphql/tck/annotations/info/package-info.java
+++ b/tck/src/main/java/org/eclipse/microprofile/graphql/tck/annotations/info/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2019 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ /*
+  * This package is for testing the @Info annotation
+  */
+package org.eclipse.microprofile.graphql.tck.annotations.info;

--- a/tck/src/main/java/org/eclipse/microprofile/graphql/tck/annotations/inputfield/package-info.java
+++ b/tck/src/main/java/org/eclipse/microprofile/graphql/tck/annotations/inputfield/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2019 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ /*
+  * This package is for testing the @InputField annotation
+  */
+package org.eclipse.microprofile.graphql.tck.annotations.inputfield;

--- a/tck/src/main/java/org/eclipse/microprofile/graphql/tck/annotations/inputfieldorder/package-info.java
+++ b/tck/src/main/java/org/eclipse/microprofile/graphql/tck/annotations/inputfieldorder/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2019 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ /*
+  * This package is for testing the @InputFieldOrder annotation
+  */
+package org.eclipse.microprofile.graphql.tck.annotations.inputfieldorder;

--- a/tck/src/main/java/org/eclipse/microprofile/graphql/tck/annotations/inputtype/package-info.java
+++ b/tck/src/main/java/org/eclipse/microprofile/graphql/tck/annotations/inputtype/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2019 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ /*
+  * This package is for testing the @InputType annotation
+  */
+package org.eclipse.microprofile.graphql.tck.annotations.inputtype;

--- a/tck/src/main/java/org/eclipse/microprofile/graphql/tck/annotations/interface/package-info.java
+++ b/tck/src/main/java/org/eclipse/microprofile/graphql/tck/annotations/interface/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2019 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ /*
+  * This package is for testing the @Interface annotation
+  */
+package org.eclipse.microprofile.graphql.tck.annotations.interface;

--- a/tck/src/main/java/org/eclipse/microprofile/graphql/tck/annotations/mutation/package-info.java
+++ b/tck/src/main/java/org/eclipse/microprofile/graphql/tck/annotations/mutation/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2019 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ /*
+  * This package is for testing the @Mutation annotation
+  */
+package org.eclipse.microprofile.graphql.tck.annotations.mutation;

--- a/tck/src/main/java/org/eclipse/microprofile/graphql/tck/annotations/query/package-info.java
+++ b/tck/src/main/java/org/eclipse/microprofile/graphql/tck/annotations/query/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2019 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ /*
+  * This package is for testing the @Query annotation
+  */
+package org.eclipse.microprofile.graphql.tck.annotations.query;

--- a/tck/src/main/java/org/eclipse/microprofile/graphql/tck/annotations/source/package-info.java
+++ b/tck/src/main/java/org/eclipse/microprofile/graphql/tck/annotations/source/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2019 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ /*
+  * This package is for testing the @Source annotation
+  */
+package org.eclipse.microprofile.graphql.tck.annotations.source;

--- a/tck/src/main/java/org/eclipse/microprofile/graphql/tck/annotations/type/package-info.java
+++ b/tck/src/main/java/org/eclipse/microprofile/graphql/tck/annotations/type/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2019 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ /*
+  * This package is for testing the @Type annotation
+  */
+package org.eclipse.microprofile.graphql.tck.annotations.type;

--- a/tck/src/main/java/org/eclipse/microprofile/graphql/tck/annotations/union/package-info.java
+++ b/tck/src/main/java/org/eclipse/microprofile/graphql/tck/annotations/union/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2019 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ /*
+  * This package is for testing the @Union annotation
+  */
+package org.eclipse.microprofile.graphql.tck.annotations.union;

--- a/tck/src/main/java/org/eclipse/microprofile/graphql/tck/apps/annotations/argument/package-info.java
+++ b/tck/src/main/java/org/eclipse/microprofile/graphql/tck/apps/annotations/argument/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2019 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ /*
+  * This package is for the applications to test the @Argument annotation
+  */
+package org.eclipse.microprofile.graphql.tck.annotations.argument;

--- a/tck/src/main/java/org/eclipse/microprofile/graphql/tck/apps/annotations/context/package-info.java
+++ b/tck/src/main/java/org/eclipse/microprofile/graphql/tck/apps/annotations/context/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2019 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ /*
+  * This package is for the applications to test the @Context annotation
+  */
+package org.eclipse.microprofile.graphql.tck.annotations.context;

--- a/tck/src/main/java/org/eclipse/microprofile/graphql/tck/apps/annotations/enum/package-info.java
+++ b/tck/src/main/java/org/eclipse/microprofile/graphql/tck/apps/annotations/enum/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2019 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ /*
+  * This package is for the applications to test the @Enum annotation
+  */
+package org.eclipse.microprofile.graphql.tck.annotations.enum;

--- a/tck/src/main/java/org/eclipse/microprofile/graphql/tck/apps/annotations/fieldorder/package-info.java
+++ b/tck/src/main/java/org/eclipse/microprofile/graphql/tck/apps/annotations/fieldorder/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2019 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ /*
+  * This package is for the applications to test the @FieldOrder annotation
+  */
+package org.eclipse.microprofile.graphql.tck.annotations.fieldorder;

--- a/tck/src/main/java/org/eclipse/microprofile/graphql/tck/apps/annotations/ignore/package-info.java
+++ b/tck/src/main/java/org/eclipse/microprofile/graphql/tck/apps/annotations/ignore/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2019 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ /*
+  * This package is for the applications to test the @Ignore annotation
+  */
+package org.eclipse.microprofile.graphql.tck.annotations.ignore;

--- a/tck/src/main/java/org/eclipse/microprofile/graphql/tck/apps/annotations/info/package-info.java
+++ b/tck/src/main/java/org/eclipse/microprofile/graphql/tck/apps/annotations/info/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2019 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ /*
+  * This package is for the applications to test the @Info annotation
+  */
+package org.eclipse.microprofile.graphql.tck.annotations.info;

--- a/tck/src/main/java/org/eclipse/microprofile/graphql/tck/apps/annotations/inputfield/package-info.java
+++ b/tck/src/main/java/org/eclipse/microprofile/graphql/tck/apps/annotations/inputfield/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2019 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ /*
+  * This package is for the applications to test the @InputField annotation
+  */
+package org.eclipse.microprofile.graphql.tck.annotations.inputfield;

--- a/tck/src/main/java/org/eclipse/microprofile/graphql/tck/apps/annotations/inputfieldorder/package-info.java
+++ b/tck/src/main/java/org/eclipse/microprofile/graphql/tck/apps/annotations/inputfieldorder/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2019 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ /*
+  * This package is for the applications to test the @InputFieldOrder annotation
+  */
+package org.eclipse.microprofile.graphql.tck.annotations.inputfieldorder;

--- a/tck/src/main/java/org/eclipse/microprofile/graphql/tck/apps/annotations/inputtype/package-info.java
+++ b/tck/src/main/java/org/eclipse/microprofile/graphql/tck/apps/annotations/inputtype/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2019 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ /*
+  * This package is for the applications to test the @InputType annotation
+  */
+package org.eclipse.microprofile.graphql.tck.annotations.inputtype;

--- a/tck/src/main/java/org/eclipse/microprofile/graphql/tck/apps/annotations/interface/package-info.java
+++ b/tck/src/main/java/org/eclipse/microprofile/graphql/tck/apps/annotations/interface/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2019 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ /*
+  * This package is for the applications to test the @Interface annotation
+  */
+package org.eclipse.microprofile.graphql.tck.annotations.interface;

--- a/tck/src/main/java/org/eclipse/microprofile/graphql/tck/apps/annotations/mutation/package-info.java
+++ b/tck/src/main/java/org/eclipse/microprofile/graphql/tck/apps/annotations/mutation/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2019 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ /*
+  * This package is for the applications to test the @Mutation annotation
+  */
+package org.eclipse.microprofile.graphql.tck.annotations.mutation;

--- a/tck/src/main/java/org/eclipse/microprofile/graphql/tck/apps/annotations/query/package-info.java
+++ b/tck/src/main/java/org/eclipse/microprofile/graphql/tck/apps/annotations/query/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2019 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ /*
+  * This package is for the applications to test the @Query annotation
+  */
+package org.eclipse.microprofile.graphql.tck.annotations.query;

--- a/tck/src/main/java/org/eclipse/microprofile/graphql/tck/apps/annotations/source/package-info.java
+++ b/tck/src/main/java/org/eclipse/microprofile/graphql/tck/apps/annotations/source/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2019 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ /*
+  * This package is for the applications to test the @Source annotation
+  */
+package org.eclipse.microprofile.graphql.tck.annotations.source;

--- a/tck/src/main/java/org/eclipse/microprofile/graphql/tck/apps/annotations/type/package-info.java
+++ b/tck/src/main/java/org/eclipse/microprofile/graphql/tck/apps/annotations/type/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2019 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ /*
+  * This package is for the applications to test the @Type annotation
+  */
+package org.eclipse.microprofile.graphql.tck.annotations.type;

--- a/tck/src/main/java/org/eclipse/microprofile/graphql/tck/apps/annotations/union/package-info.java
+++ b/tck/src/main/java/org/eclipse/microprofile/graphql/tck/apps/annotations/union/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2019 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ /*
+  * This package is for the applications to test the @Union annotation
+  */
+package org.eclipse.microprofile.graphql.tck.annotations.union;


### PR DESCRIPTION
This PR creates the directory structure that we intend to follow for the TCK and adds package-info.java files to each which comment on which tests should go in the respective directories.