### PR TITLE
Remove reserved words from package names

### DIFF
--- a/tck/src/main/java/org/eclipse/microprofile/graphql/tck/annotations/enumeration/package-info.java
+++ b/tck/src/main/java/org/eclipse/microprofile/graphql/tck/annotations/enumeration/package-info.java
@@ -16,6 +16,6 @@
  * limitations under the License.
  */
  /*
-  * This package is for the applications to test the @Interface annotation
+  * This package is for testing the @Enum annotation
   */
-package org.eclipse.microprofile.graphql.tck.annotations.interface;
+package org.eclipse.microprofile.graphql.tck.annotations.enumeration;

--- a/tck/src/main/java/org/eclipse/microprofile/graphql/tck/annotations/intf/package-info.java
+++ b/tck/src/main/java/org/eclipse/microprofile/graphql/tck/annotations/intf/package-info.java
@@ -16,6 +16,6 @@
  * limitations under the License.
  */
  /*
-  * This package is for the applications to test the @Enum annotation
+  * This package is for testing the @Interface annotation
   */
-package org.eclipse.microprofile.graphql.tck.annotations.enum;
+package org.eclipse.microprofile.graphql.tck.annotations.intf;

--- a/tck/src/main/java/org/eclipse/microprofile/graphql/tck/apps/annotations/enumeration/package-info.java
+++ b/tck/src/main/java/org/eclipse/microprofile/graphql/tck/apps/annotations/enumeration/package-info.java
@@ -16,6 +16,6 @@
  * limitations under the License.
  */
  /*
-  * This package is for testing the @Enum annotation
+  * This package is for the applications to test the @Enum annotation
   */
-package org.eclipse.microprofile.graphql.tck.annotations.enum;
+package org.eclipse.microprofile.graphql.tck.annotations.enumeration;

--- a/tck/src/main/java/org/eclipse/microprofile/graphql/tck/apps/annotations/intf/package-info.java
+++ b/tck/src/main/java/org/eclipse/microprofile/graphql/tck/apps/annotations/intf/package-info.java
@@ -16,6 +16,6 @@
  * limitations under the License.
  */
  /*
-  * This package is for testing the @Interface annotation
+  * This package is for the applications to test the @Interface annotation
   */
-package org.eclipse.microprofile.graphql.tck.annotations.interface;
+package org.eclipse.microprofile.graphql.tck.annotations.intf;


### PR DESCRIPTION
This should resolve issue #6.  Making this change now to be able to compile successfully for building an early access (milestone) release.

Signed-off-by: Andy McCright <j.andrew.mccright@gmail.com>