### PR TITLE
[Issue 26] TCK - look up data only if client asks

### DIFF
--- a/tck/src/main/java/org/eclipse/microprofile/graphql/tck/apps/superhero/api/HeroFinder.java
+++ b/tck/src/main/java/org/eclipse/microprofile/graphql/tck/apps/superhero/api/HeroFinder.java
@@ -27,9 +27,10 @@ import org.eclipse.microprofile.graphql.Argument;
 import org.eclipse.microprofile.graphql.GraphQLApi;
 import org.eclipse.microprofile.graphql.Mutation;
 import org.eclipse.microprofile.graphql.Query;
-
+import org.eclipse.microprofile.graphql.Source;
 import org.eclipse.microprofile.graphql.tck.apps.superhero.db.DuplicateSuperHeroException;
 import org.eclipse.microprofile.graphql.tck.apps.superhero.db.HeroDatabase;
+import org.eclipse.microprofile.graphql.tck.apps.superhero.db.HeroLocator;
 import org.eclipse.microprofile.graphql.tck.apps.superhero.db.UnknownHeroException;
 import org.eclipse.microprofile.graphql.tck.apps.superhero.db.UnknownTeamException;
 import org.eclipse.microprofile.graphql.tck.apps.superhero.model.Item;
@@ -42,6 +43,9 @@ public class HeroFinder {
     
     @Inject
     HeroDatabase heroDB;
+
+    @Inject
+    HeroLocator heroLocator;
 
     @Query
     public SuperHero superHero(@Argument("name") String name) {
@@ -140,6 +144,12 @@ public class HeroFinder {
         hero.getEquipment().removeIf( i -> { 
             return i.getId() == itemID;} );
         return hero;
+    }
+
+    @Query
+    public String currentLocation(@Source SuperHero hero) {
+        LOG.info("checking current location for: " + hero.getName());
+        return heroLocator.getHeroLocation(hero.getName());
     }
 
     private Collection<SuperHero> allHeroesByFilter(Predicate<SuperHero> predicate) {

--- a/tck/src/main/java/org/eclipse/microprofile/graphql/tck/apps/superhero/db/HeroLocator.java
+++ b/tck/src/main/java/org/eclipse/microprofile/graphql/tck/apps/superhero/db/HeroLocator.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.eclipse.microprofile.graphql.tck.apps.superhero.db;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.context.Initialized;
+import javax.enterprise.event.Observes;
+
+@ApplicationScoped
+public class HeroLocator {
+    final Map<String,String> heroLocations = new HashMap<>();
+
+    protected void init(@Observes @Initialized(ApplicationScoped.class) Object init) {
+        heroLocations.put("Iron Man", "Wachovia");
+        heroLocations.put("Spider Man", "Brooklyn");
+        heroLocations.put("Starlord", "Xandar");
+        heroLocations.put("Wolverine", "New Orleans");
+    }
+
+    public String getHeroLocation(String name) {
+        return heroLocations.getOrDefault(name, "Whereabouts unknown...");
+    }
+}

--- a/tck/src/main/resources/tests/allHeroesWithCurrentLocation/input.graphql
+++ b/tck/src/main/resources/tests/allHeroesWithCurrentLocation/input.graphql
@@ -1,0 +1,6 @@
+query allHeroes {
+    allHeroes {
+        name
+        currentLocation
+    }
+}

--- a/tck/src/main/resources/tests/allHeroesWithCurrentLocation/output.json
+++ b/tck/src/main/resources/tests/allHeroesWithCurrentLocation/output.json
@@ -1,0 +1,22 @@
+{
+  "data": {
+    "allHeroes": [
+      {
+        "name": "Iron Man",
+        "currentLocation": "Wachovia"
+      },
+      {
+        "name": "Starlord",
+        "currentLocation": "Xandar"
+      },
+      {
+        "name": "Wolverine",
+        "currentLocation": "New Orleans"
+      },
+      {
+        "name": "Spider Man",
+        "currentLocation": "Brooklyn"
+      }
+    ]
+  }
+}

--- a/tck/src/main/resources/tests/allHeroesWithCurrentLocation/test.properties
+++ b/tck/src/main/resources/tests/allHeroesWithCurrentLocation/test.properties
@@ -1,0 +1,7 @@
+# This tests that a `currentLocation` method is invoked to determine the location from a different back end
+# "database".  Because this database is expensive, we only want to look up the location if the client has
+# actually requested this information.
+# TODO: ideally we would test that the `currentLocation` is not invoked on other requests, but only when the
+# user explicitly requests it.
+ignore=false
+priority=100


### PR DESCRIPTION
Partially resolves issue #26 - this allows an app to only perform certain back-end lookups if the user specifically asks for that field.

This is the second example in this comment:
https://github.com/eclipse/microprofile-graphql/issues/26#issuecomment-512861660

This PR includes the updates to the test application and the dynamic test data.  It does not completely resolve issue #26 because we still need:
* documentation on this process in the spec text
* a mechanism for conditional lookups (i.e. the first example in the comment mentioned above)

Side note:  while this test shows that the `currentLocation` method is invoked when the user asks for it, it does not test the opposite - that the method is _not_ invoked when the user _does not_ ask for it.  This might require a separate test outside of the dynamic test infrastructure.

Signed-off-by: Andy McCright <j.andrew.mccright@gmail.com>