### PR TITLE
Issue 43: New TCK test for "rivalTeam"

### DIFF
--- a/tck/src/main/java/org/eclipse/microprofile/graphql/tck/apps/superhero/api/HeroFinder.java
+++ b/tck/src/main/java/org/eclipse/microprofile/graphql/tck/apps/superhero/api/HeroFinder.java
@@ -158,4 +158,14 @@ public class HeroFinder {
                      .filter(predicate)
                      .collect(Collectors.toCollection(ArrayList::new));
     }
+
+    @Mutation
+    public Team setRivalTeam(@Argument("teamName") String teamName, @Argument("rivalTeam") Team rivalTeam) 
+        throws UnknownTeamException {
+
+        LOG.info("setRivalTeam: " + teamName + "'s new rival is: " + rivalTeam == null ? "null" : rivalTeam.getName());
+        Team team = heroDB.getTeam(teamName);
+        team.setRivalTeam(rivalTeam);
+        return team;
+    }
 }

--- a/tck/src/main/java/org/eclipse/microprofile/graphql/tck/apps/superhero/model/Team.java
+++ b/tck/src/main/java/org/eclipse/microprofile/graphql/tck/apps/superhero/model/Team.java
@@ -21,6 +21,7 @@ public class Team {
 
     private String name;
     private List<SuperHero> members;
+    private Team rivalTeam;
 
     public Team(){
     
@@ -58,5 +59,13 @@ public class Team {
             members.remove(hero);
         }
         return this;
+    }
+
+    public Team getRivalTeam() {
+        return rivalTeam;
+    }
+
+    public void setRivalTeam(Team rivalTeam) {
+        this.rivalTeam = rivalTeam;
     }
 }

--- a/tck/src/main/resources/tests/setRivalTeam/cleanup.graphql
+++ b/tck/src/main/resources/tests/setRivalTeam/cleanup.graphql
@@ -1,0 +1,8 @@
+mutation unsetXMenRivalTeam {
+  setRivalTeam (teamName:"X-Men", rivalTeam:null) {
+    name,
+    rivalTeam {
+      name
+    }
+  }
+}

--- a/tck/src/main/resources/tests/setRivalTeam/input.graphql
+++ b/tck/src/main/resources/tests/setRivalTeam/input.graphql
@@ -1,0 +1,10 @@
+mutation setXMenRivalTeam {
+  setRivalTeam (teamName:"X-Men", rivalTeam:{
+    name:"Brotherhood of Evil Mutants"
+  }) {
+    name,
+    rivalTeam {
+      name
+    }
+  }
+}

--- a/tck/src/main/resources/tests/setRivalTeam/output.json
+++ b/tck/src/main/resources/tests/setRivalTeam/output.json
@@ -1,0 +1,10 @@
+{
+  "data": {
+    "setRivalTeam": {
+      "name": "X-Men",
+      "rivalTeam": {
+        "name": "Brotherhood of Evil Mutants"
+      }
+    }
+  }
+}

--- a/tck/src/main/resources/tests/setRivalTeam/test.properties
+++ b/tck/src/main/resources/tests/setRivalTeam/test.properties
@@ -1,0 +1,3 @@
+# Tests entities that reference their own types - in this case Team has a Team field for "rivalTeam".
+ignore=false
+priority=50


### PR DESCRIPTION
Ensures that an entity object can have a field of the same type of entity - i.e. `Team` has a `Team rivalTeam` field.

Resolves issue #43.