### PR TITLE
Issue 17: FieldsOrder/InputFieldsOrder text + TCK

### DIFF
--- a/spec/src/main/asciidoc/entities.asciidoc
+++ b/spec/src/main/asciidoc/entities.asciidoc
@@ -73,7 +73,7 @@ TODO: info on limitations to generic types (collections only?)
 
 === Fields
 
-=== Deprecation
+==== Deprecation
 
 Application developers can mark entity fields as deprecated in the GraphQL schema with the `@Deprecated` annotation -
 either the annotation that comes from the JDK in the `java.lang` package or the MicroProfile GraphQL annotation in the
@@ -88,7 +88,34 @@ effect if specified on output types.  The value specified in this annotation may
 
 ==== FieldsOrder / InputFieldsOrder
 
-TODO: info on fields ordering
+It is possible to control the order that entity type fields and input type fields are ordered in the schema using the 
+`@FieldsOrder` and `@InputFieldsOrder` annotations, respectively.  The value of these annotations is a String array that
+determines the order of the fields for the specified type or input type.  If a field name is specified, that does not 
+exist, the implementation should ignore that field and it _should_ log a warning.  If a field name exists on the type or
+input type, but is not specified, it's location in the schema is undefined, but will not be displayed before any of the
+fields listed in the annotation.  Consider the following example:
+
+```
+@FieldsOrder({"foo", "oops", "cat", "baz"})
+public class MyType {
+    private String cat;
+    private String baz;
+    private String bar;
+    private String foo;
+    private String dog;
+}
+```
+
+In this example, `MyType` has five fields: `cat`, `baz`, `bar`, `foo`, and `dog`.  The `@FieldsOrder` annotation 
+specifies three of these fields and another field that does not exist.  The order in the schema should be:
+
+- foo
+- cat
+- baz
+- bar or dog - this order is non-deterministic
+- dog or bar - this order is non-deterministic
+
+The implementation should also log a warning that indicates that `oops` is not a valid field.
 
 ==== Ignorable fields
 

--- a/tck/src/main/java/org/eclipse/microprofile/graphql/tck/SchemaAvailableTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/graphql/tck/SchemaAvailableTest.java
@@ -61,23 +61,33 @@ public class SchemaAvailableTest extends Arquillian {
     @Test
     @RunAsClient
     public void testResponse() throws Exception {
-        URL url = new URL(this.uri + PATH);
-        HttpURLConnection connection = (HttpURLConnection) url.openConnection();
         
-        connection.setRequestMethod("GET");
-        connection.setRequestProperty("Content-Type", "plain/text");
-        
-        // Check the response code
-        int responseCode = connection.getResponseCode();
-        Assert.assertEquals(responseCode, 200, "While testing [" + url.toString() + "]");
-        
-        // Check the content
-        String content = getContent(connection);
-        Assert.assertTrue(content.length() > 0 , "While testing [" + url.toString() + "]");
-        
-        connection.disconnect();
+        // Check that there is some content
+        String content = getSchemaContent();
+        Assert.assertTrue(content.length() > 0);
     }
-    
+
+    private String getSchemaContent() throws Exception {
+        URL url = new URL(this.uri + PATH);
+        HttpURLConnection connection = null;
+        try {
+            connection = (HttpURLConnection) url.openConnection();
+
+            connection.setRequestMethod("GET");
+            connection.setRequestProperty("Content-Type", "plain/text");
+
+            // Check the response code
+            int responseCode = connection.getResponseCode();
+            Assert.assertEquals(responseCode, 200, "While testing [" + url.toString() + "]");
+
+            return getContent(connection);
+        } finally {
+            if (connection != null) {
+                connection.disconnect();
+            }
+        }
+    }
+
     private String getContent(HttpURLConnection connection) throws IOException{
         try (StringWriter sw = new StringWriter();
                 BufferedReader in = new BufferedReader(new InputStreamReader(connection.getInputStream()))) {
@@ -88,6 +98,80 @@ public class SchemaAvailableTest extends Arquillian {
             return sw.toString();
         }
     }
-    
-}
 
+    @Test
+    @RunAsClient
+    public void testFieldOrder() throws Exception {
+        String schema = getSchemaContent();
+        int typeIndex = schema.indexOf("type SuperHero");
+        Assert.assertNotEquals(typeIndex, -1, "Did not find expected \"type SuperHero\"");
+        int inputTypeIndex = schema.indexOf("input SuperHeroInput");
+        Assert.assertNotEquals(inputTypeIndex, -1, "Did not find expected \"input SuperHeroInput\"");
+        int end = typeIndex < inputTypeIndex ? inputTypeIndex : schema.length() -1;
+        String typeFields = schema.substring(typeIndex, end);
+        LOG.info("typeFields from schema = " + typeFields);
+
+        int teamAffiliationIndex = typeFields.indexOf("teamAffiliation");
+        int superPowersIndex = typeFields.indexOf("superPowers");
+        int primaryLocationIndex = typeFields.indexOf("primaryLocation");
+        int nameIndex = typeFields.indexOf("name");
+        int realNameIndex = typeFields.indexOf("realName");
+        int equipmentIndex = typeFields.indexOf("equipment");
+
+        Assert.assertNotEquals(teamAffiliationIndex, -1, "Did not find expected field, \"teamAffiliation\"");
+        Assert.assertNotEquals(superPowersIndex, -1, "Did not find expected field, \"superPowers\"");
+        Assert.assertNotEquals(primaryLocationIndex, -1, "Did not find expected field, \"primaryLocation\"");
+        Assert.assertNotEquals(nameIndex, -1, "Did not find expected field, \"name\"");
+        Assert.assertNotEquals(realNameIndex, -1, "Did not find expected field, \"realName\"");
+        Assert.assertNotEquals(equipmentIndex, -1, "Did not find expected field, \"equipment\"");
+
+        Assert.assertTrue(nameIndex < realNameIndex, 
+                "Expected field \"name\" to preceed field \"realName\", but did not");
+        Assert.assertTrue(realNameIndex < superPowersIndex,
+                "Expected field \"realName\" to preceed field \"superPowers\", but did not");
+        Assert.assertTrue(superPowersIndex < teamAffiliationIndex,
+                "Expected field \"superPowers\" to preceed field \"teamAffiliation\", but did not");
+        Assert.assertTrue(superPowersIndex < primaryLocationIndex,
+                "Expected field \"superPowers\" to preceed field \"primaryLocation\", but did not");
+        Assert.assertTrue(superPowersIndex < equipmentIndex,
+                "Expected field \"superPowers\" to preceed field \"equipment\", but did not");
+    }
+
+    @Test
+    @RunAsClient
+    public void testInputFieldOrder() throws Exception {
+        String schema = getSchemaContent();
+        int typeIndex = schema.indexOf("type SuperHero");
+        Assert.assertNotEquals(typeIndex, -1, "Did not find expected \"type SuperHero\"");
+        int inputTypeIndex = schema.indexOf("input SuperHeroInput");
+        Assert.assertNotEquals(inputTypeIndex, -1, "Did not find expected \"input SuperHeroInput\"");
+        int end = inputTypeIndex < typeIndex ? typeIndex : schema.length() - 1;
+        String inputTypeFields = schema.substring(typeIndex, end);
+        LOG.info("inputTypeFields from schema = " + inputTypeFields);
+
+        int teamAffiliationIndex = inputTypeFields.indexOf("teamAffiliation");
+        int superPowersIndex = inputTypeFields.indexOf("superPowers");
+        int primaryLocationIndex = inputTypeFields.indexOf("primaryLocation");
+        int nameIndex = inputTypeFields.indexOf("name");
+        int realNameIndex = inputTypeFields.indexOf("realName");
+        int equipmentIndex = inputTypeFields.indexOf("equipment");
+
+        Assert.assertNotEquals(teamAffiliationIndex, -1, "Did not find expected field, \"teamAffiliation\"");
+        Assert.assertNotEquals(superPowersIndex, -1, "Did not find expected field, \"superPowers\"");
+        Assert.assertNotEquals(primaryLocationIndex, -1, "Did not find expected field, \"primaryLocation\"");
+        Assert.assertNotEquals(nameIndex, -1, "Did not find expected field, \"name\"");
+        Assert.assertNotEquals(realNameIndex, -1, "Did not find expected field, \"realName\"");
+        Assert.assertNotEquals(equipmentIndex, -1, "Did not find expected field, \"equipment\"");
+
+        Assert.assertTrue(primaryLocationIndex < teamAffiliationIndex,
+                "Expected field \"primaryLocation\" to preceed field \"teamAffiliation\", but did not");
+        Assert.assertTrue(teamAffiliationIndex < nameIndex,
+                "Expected field \"teamAffiliation\" to preceed field \"name\", but did not");
+        Assert.assertTrue(nameIndex < superPowersIndex,
+                "Expected field \"name\" to preceed field \"superPowers\", but did not");
+        Assert.assertTrue(nameIndex < realNameIndex,
+                "Expected field \"name\" to preceed field \"realName\", but did not");
+        Assert.assertTrue(nameIndex < equipmentIndex,
+                "Expected field \"name\" to preceed field \"equipment\", but did not");
+    }
+}

--- a/tck/src/main/java/org/eclipse/microprofile/graphql/tck/apps/superhero/model/SuperHero.java
+++ b/tck/src/main/java/org/eclipse/microprofile/graphql/tck/apps/superhero/model/SuperHero.java
@@ -18,6 +18,11 @@ package org.eclipse.microprofile.graphql.tck.apps.superhero.model;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.eclipse.microprofile.graphql.FieldsOrder;
+import org.eclipse.microprofile.graphql.InputFieldsOrder;
+
+@FieldsOrder({"name", "realName", "superPowers", "cuurentLocation", "primaryLocation", "teamAffiliations", "equipment"})
+@InputFieldsOrder({"primaryLocation", "teamAffiliations", "name", "equipment", "realName", "superPowers"})
 public class SuperHero {
     private List<Team> teamAffiliations;
     private List<String> superPowers;


### PR DESCRIPTION
This should probably be considered a work in progress for now.  I would like a review on the spec text and TCK test cases proposal to confirm that this is the behavior we want to see.  Currently, these TCK tests fail for me with the current implementation in OpenLiberty - I need to investigate further to understand why, but I would prefer not to merge this PR until it passes (or at least until we know what is causing the failure).

Once completed, this should resolve issue #17.