### PR TITLE
Issue 46: TCK Tests for `@DefaultValue` annotation

### DIFF
--- a/spec/src/main/asciidoc/entities.asciidoc
+++ b/spec/src/main/asciidoc/entities.asciidoc
@@ -84,7 +84,8 @@ might provide more information to the consumers of the schema.
 
 The `@DefaultValue` annotation may be used to specify a value in an input type to be used if the client did not specify
 a value. Default values may only be specified on input types (and also as `@Argument` parameters) and will have no
-effect if specified on output types.  The value specified in this annotation may be
+effect if specified on output types.  The value specified in this annotation may be plain text for Java primitives and 
+`String` types or JSON for complex types.
 
 ==== FieldsOrder / InputFieldsOrder
 

--- a/tck/src/main/java/org/eclipse/microprofile/graphql/tck/apps/superhero/api/HeroFinder.java
+++ b/tck/src/main/java/org/eclipse/microprofile/graphql/tck/apps/superhero/api/HeroFinder.java
@@ -24,6 +24,7 @@ import java.util.stream.Collectors;
 import javax.inject.Inject;
 
 import org.eclipse.microprofile.graphql.Argument;
+import org.eclipse.microprofile.graphql.DefaultValue;
 import org.eclipse.microprofile.graphql.GraphQLApi;
 import org.eclipse.microprofile.graphql.Mutation;
 import org.eclipse.microprofile.graphql.Query;
@@ -60,8 +61,8 @@ public class HeroFinder {
     }
     
     @Query
-    public Collection<SuperHero> allHeroesIn(@Argument("city") String city) {
-        LOG.info("allHeroesIn invoked");
+    public Collection<SuperHero> allHeroesIn(@DefaultValue("New York, NY") @Argument("city") String city) {
+        LOG.info("allHeroesIn " + city + " invoked");
         return allHeroesByFilter(hero -> {
             return city.equals(hero.getPrimaryLocation());});
     }
@@ -121,7 +122,7 @@ public class HeroFinder {
 
     @Mutation(description="Gives a hero new equipment")
     public SuperHero provisionHero(@Argument("hero") String heroName,
-                                   @Argument("item") Item item) 
+                                   @DefaultValue(Item.CAPE) @Argument("item") Item item) 
                                    throws UnknownHeroException {
         LOG.info("provisionHero invoked");
         SuperHero hero = heroDB.getHero(heroName);
@@ -144,6 +145,22 @@ public class HeroFinder {
         hero.getEquipment().removeIf( i -> { 
             return i.getId() == itemID;} );
         return hero;
+    }
+
+    @Mutation(description="Update an item's powerLevel") 
+    public Item updateItemPowerLevel(@Argument("itemID") long itemID,
+                                     @DefaultValue("5") @Argument("powerLevel") int newLevel) {
+
+        Item item = null;
+        for (SuperHero hero : allHeroes()) {
+            for (Item i : hero.getEquipment()) {
+                if (i.getId() == itemID) {
+                    item = i;
+                    item.setPowerLevel(newLevel);
+                }
+            }
+        }
+        return item;
     }
 
     @Query

--- a/tck/src/main/java/org/eclipse/microprofile/graphql/tck/apps/superhero/db/HeroDatabase.java
+++ b/tck/src/main/java/org/eclipse/microprofile/graphql/tck/apps/superhero/db/HeroDatabase.java
@@ -124,7 +124,9 @@ public class HeroDatabase {
              "\"realName\":\"Tony Stark\"," +
              "\"primaryLocation\":\"Los Angeles, CA\"," +
              "\"superPowers\":[\"wealth\",\"engineering\"]," +
-             "\"teamAffiliations\":[{\"name\":\"Avengers\"}]" +
+             "\"teamAffiliations\":[{\"name\":\"Avengers\"}]," +
+             "\"equipment\":[{\"id\": 1001, \"name\": \"Iron Man Suit\", \"powerLevel\": 18, " +
+                             "\"height\": 1.8, \"weight\": 120.7, \"supernatural\": false}]" +
             "}," +
             "{" +
              "\"name\":\"Spider Man\"," +

--- a/tck/src/main/java/org/eclipse/microprofile/graphql/tck/apps/superhero/model/Item.java
+++ b/tck/src/main/java/org/eclipse/microprofile/graphql/tck/apps/superhero/model/Item.java
@@ -27,6 +27,16 @@ public class Item {
     private float weight;
     private boolean supernatural;
 
+    public final static String CAPE =
+        "{" +
+        "   \"id\": 1000," +
+        "   \"name\": \"Cape\","+
+        "   \"powerLevel\": 3," +
+        "   \"height\": 1.2," +
+        "   \"weight\": 0.3," +
+        "   \"supernatural\": false" +
+        "}";
+
     public Item(){
     }
     

--- a/tck/src/main/java/org/eclipse/microprofile/graphql/tck/apps/superhero/model/SuperHero.java
+++ b/tck/src/main/java/org/eclipse/microprofile/graphql/tck/apps/superhero/model/SuperHero.java
@@ -24,7 +24,7 @@ public class SuperHero {
     private String primaryLocation;
     private String name;
     private String realName;
-    private final List<Item> equipment = new ArrayList<>();
+    private List<Item> equipment = new ArrayList<>();
 
     public SuperHero(){
     }
@@ -84,5 +84,9 @@ public class SuperHero {
 
     public List<Item> getEquipment() {
         return equipment;
+    }
+
+    public void setEquipment(List<Item> equipment) {
+        this.equipment = equipment;
     }
 }

--- a/tck/src/main/resources/tests/addItemToHeroUsingDefaultValue/cleanup.graphql
+++ b/tck/src/main/resources/tests/addItemToHeroUsingDefaultValue/cleanup.graphql
@@ -1,0 +1,9 @@
+mutation removeCape {
+  removeItemFromHero(hero:"Spider Man", itemID:1000){
+    name,
+    equipment {
+      id,
+      name
+    }
+  }
+}

--- a/tck/src/main/resources/tests/addItemToHeroUsingDefaultValue/input.graphql
+++ b/tck/src/main/resources/tests/addItemToHeroUsingDefaultValue/input.graphql
@@ -1,0 +1,14 @@
+# Tests that the implementation can a default value on a POJO in a mutation
+mutation giveSpiderManACape {
+  provisionHero(hero:"Spider Man") {
+    name,
+    equipment {
+      id,
+      name,
+      height,
+      weight,
+      powerLevel,
+      supernatural
+    }
+  }
+}

--- a/tck/src/main/resources/tests/addItemToHeroUsingDefaultValue/output.json
+++ b/tck/src/main/resources/tests/addItemToHeroUsingDefaultValue/output.json
@@ -1,0 +1,17 @@
+{
+  "data": {
+    "provisionHero": {
+      "name": "Spider Man",
+      "equipment": [
+        {
+          "id": 1000,
+          "name": "Cape",
+          "height": 1.2,
+          "weight": 0.3,
+          "powerLevel": 3,
+          "supernatural": false
+        }
+      ]
+    }
+  }
+}

--- a/tck/src/main/resources/tests/addItemToHeroUsingDefaultValue/test.properties
+++ b/tck/src/main/resources/tests/addItemToHeroUsingDefaultValue/test.properties
@@ -1,0 +1,3 @@
+# This tests that a default value can apply to a POJO with a fromString method in a mutation
+ignore=false
+priority=200

--- a/tck/src/main/resources/tests/allHeroesInDefaultLocation/input.graphql
+++ b/tck/src/main/resources/tests/allHeroesInDefaultLocation/input.graphql
@@ -1,0 +1,8 @@
+query allHeroesInNYC {
+    allHeroesIn {
+        name
+        primaryLocation
+        superPowers
+        realName
+    }
+}

--- a/tck/src/main/resources/tests/allHeroesInDefaultLocation/output.json
+++ b/tck/src/main/resources/tests/allHeroesInDefaultLocation/output.json
@@ -1,0 +1,10 @@
+{
+    "data": {
+        "allHeroesIn": [{
+                "name": "Spider Man",
+                "primaryLocation": "New York, NY",
+                "superPowers": ["Spidey Sense", "Wall-Crawling", "Super Strength", "Web-shooting"],
+                "realName": "Peter Parker"
+            }]
+    }
+}

--- a/tck/src/main/resources/tests/allHeroesInDefaultLocation/test.properties
+++ b/tck/src/main/resources/tests/allHeroesInDefaultLocation/test.properties
@@ -1,0 +1,3 @@
+# Tests that a default location (via @DefaultValue("New York, NY")) is used when not specified in the query.
+ignore=false
+priority=100

--- a/tck/src/main/resources/tests/updateItemPowerLevel/cleanup.graphql
+++ b/tck/src/main/resources/tests/updateItemPowerLevel/cleanup.graphql
@@ -1,0 +1,7 @@
+mutation resetIronManSuitPower {
+  updateItemPowerLevel(itemID:1001, powerLevel:18) {
+    id
+    name
+    powerLevel
+  }
+}

--- a/tck/src/main/resources/tests/updateItemPowerLevel/input.graphql
+++ b/tck/src/main/resources/tests/updateItemPowerLevel/input.graphql
@@ -1,0 +1,8 @@
+# Tests that the implementation can handle a default value on a primitive scalar (int) - powerLevel defaults to 5.
+mutation alterIronManSuitPower {
+  updateItemPowerLevel(itemID:1001) {
+    id
+    name
+    powerLevel
+  }
+}

--- a/tck/src/main/resources/tests/updateItemPowerLevel/output.json
+++ b/tck/src/main/resources/tests/updateItemPowerLevel/output.json
@@ -1,0 +1,9 @@
+{
+  "data": {
+    "updateItemPowerLevel": {
+      "id": 1001,
+      "name": "Iron Man Suit",
+      "powerLevel": 5
+    }
+  }
+}

--- a/tck/src/main/resources/tests/updateItemPowerLevel/test.properties
+++ b/tck/src/main/resources/tests/updateItemPowerLevel/test.properties
@@ -1,0 +1,3 @@
+# This tests that default values apply to primitive scalars (int)
+ignore=false
+priority=200


### PR DESCRIPTION
Includes tests where the default value is a String, int, and POJO (`Item`).
Updates to the spec text.

This should resolve issue #46.