### PR TITLE
Issue 21: Send partial results w/ GraphQLException

### DIFF
--- a/api/src/main/java/org/eclipse/microprofile/graphql/GraphQLException.java
+++ b/api/src/main/java/org/eclipse/microprofile/graphql/GraphQLException.java
@@ -33,6 +33,8 @@ public class GraphQLException extends Exception {
 
     private ExceptionType type; 
 
+    private Object partialResults;
+
     public GraphQLException() {
         super();
     }
@@ -67,6 +69,34 @@ public class GraphQLException extends Exception {
     public GraphQLException(String message, Throwable cause, ExceptionType type) {
         super(message, cause);
         this.type = type;
+    }
+
+    public GraphQLException(Object partialResults) {
+        super();
+        this.partialResults = partialResults;
+    }
+
+    public GraphQLException(String message, Object partialResults) {
+        super(message);
+        this.partialResults = partialResults;
+    }
+
+    public GraphQLException(Throwable cause, Object partialResults) {
+        super(cause);
+        this.partialResults = partialResults;
+    }
+
+    public GraphQLException(String message, Throwable cause, Object partialResults) {
+        super(message, cause);
+        this.partialResults = partialResults;
+    }
+
+    public java.lang.Object getPartialResults() {
+        return partialResults;
+    }
+
+    public void setPartialResults(Object partialResults) {
+        this.partialResults = partialResults;
     }
 
     public ExceptionType getExceptionType() {

--- a/spec/src/main/asciidoc/errorhandling.asciidoc
+++ b/spec/src/main/asciidoc/errorhandling.asciidoc
@@ -56,8 +56,38 @@ using the MicroProfile Config property, `mp.graphql.defaultErrorMessage`.
 
 === Partial Results
 
-It is possible in GraphQL to send back some results even though the overall request may have failed. This is possible
-when using multiple methods and the `@Source` annotation. Here is an example:
+It is possible in GraphQL to send back some results even though the overall request may have failed. 
+This is possible by passing the partial results to the `GraphQLException` (or subclass of `GraphQLException`) that is
+thrown by the query or mutation method.  For example:
+
+```
+@Query
+public Collection<SuperHero> allHeroesFromCalifornia() throws GraphQLException {
+    List<SuperHero> westCoastHeroes = new ArrayList<>();
+    try {
+        for (SuperHero hero : database.getAllHeroes()) {
+            if (hero.getPrimaryLocation().contains("California")) {
+                westCoastHeroes.add(hero);
+            }
+        }
+    } catch (Exception ex) {
+        throw new GraphQLException(ex, westCoastHeroes);
+    }
+    return westCoastHeroes;
+}
+```
+
+If an exception is thrown while iterating over of the database collection of heroes or while checking a hero's location,
+all previously-processed heroes will still be in the list and will be displayed to the client along with the error
+data.
+
+Note that the `partialResults` object passed to the `GraphQLException` must match the return type of the query/mutation
+method from which it is thrown. Otherwise the implementation must throw a `ClassCastException` internally resulting in
+a much less usable result returned to the client.
+
+It is also possible to send partial results when using multiple methods and the `@Source` annotation. Here is an
+example:
+
 ```
 @Query
 public Collection<SuperHero> allHeroes() {

--- a/tck/src/main/java/org/eclipse/microprofile/graphql/tck/apps/superhero/api/HeroFinder.java
+++ b/tck/src/main/java/org/eclipse/microprofile/graphql/tck/apps/superhero/api/HeroFinder.java
@@ -17,6 +17,7 @@ package org.eclipse.microprofile.graphql.tck.apps.superhero.api;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 import java.util.function.Predicate;
 import java.util.logging.Logger;
@@ -34,6 +35,7 @@ import org.eclipse.microprofile.graphql.Source;
 import org.eclipse.microprofile.graphql.tck.apps.superhero.db.DuplicateSuperHeroException;
 import org.eclipse.microprofile.graphql.tck.apps.superhero.db.HeroDatabase;
 import org.eclipse.microprofile.graphql.tck.apps.superhero.db.HeroLocator;
+import org.eclipse.microprofile.graphql.tck.apps.superhero.db.SuperHeroLookupException;
 import org.eclipse.microprofile.graphql.tck.apps.superhero.db.UnknownHeroException;
 import org.eclipse.microprofile.graphql.tck.apps.superhero.db.UnknownTeamException;
 import org.eclipse.microprofile.graphql.tck.apps.superhero.model.Item;
@@ -190,5 +192,31 @@ public class HeroFinder {
         Team team = heroDB.getTeam(teamName);
         team.setRivalTeam(rivalTeam);
         return team;
+    }
+
+    @Query
+    public Collection<SuperHero> allHeroesWithError() throws GraphQLException {
+        LOG.info("allHeroesWithError invoked");
+        List<SuperHero> partialHeroes = new ArrayList<>();
+        for (SuperHero hero : heroDB.getAllHeroes()) {
+            if ("Starlord".equals(hero.getName())) {
+                partialHeroes.add(null);
+            } else {
+                partialHeroes.add(hero);
+            }
+        }
+        throw new GraphQLException("Failed to find one or more heroes", partialHeroes);
+    }
+
+    @Query
+    public Collection<SuperHero> allHeroesWithSpecificError() throws SuperHeroLookupException {
+        LOG.info("allHeroesWithError invoked");
+        List<SuperHero> partialHeroes = new ArrayList<>();
+        for (SuperHero hero : heroDB.getAllHeroes()) {
+            if (!"Spider Man".equals(hero.getName())) {
+                partialHeroes.add(hero);
+            }
+        }
+        throw new SuperHeroLookupException("Failed to find one or more heroes", partialHeroes);
     }
 }

--- a/tck/src/main/java/org/eclipse/microprofile/graphql/tck/apps/superhero/api/SuperHeroLookupException.java
+++ b/tck/src/main/java/org/eclipse/microprofile/graphql/tck/apps/superhero/api/SuperHeroLookupException.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.eclipse.microprofile.graphql.tck.apps.superhero.api;
+
+import org.eclipse.microprofile.graphql.GraphQLException;
+
+@SuppressWarnings("serial")
+public class SuperHeroLookupException extends GraphQLException {
+
+    public SuperHeroLookupException(String message, Object partialResults) {
+        super(message, partialResults);
+    }
+}

--- a/tck/src/main/resources/tests/ex_partialResultsAfterNewHeroNoLocation/output.json
+++ b/tck/src/main/resources/tests/ex_partialResultsAfterNewHeroNoLocation/output.json
@@ -43,8 +43,7 @@
         }
       ],
       "errorType": "DataFetchingException",
-      "path": null,
-      "extensions": null
+      "path": null
     }
   ]
 }

--- a/tck/src/main/resources/tests/ex_partialResultsInGraphQLException/input.graphql
+++ b/tck/src/main/resources/tests/ex_partialResultsInGraphQLException/input.graphql
@@ -1,0 +1,6 @@
+query allHeroesWithError {
+    allHeroesWithError {
+        name
+        primaryLocation
+    }
+}

--- a/tck/src/main/resources/tests/ex_partialResultsInGraphQLException/output.json
+++ b/tck/src/main/resources/tests/ex_partialResultsInGraphQLException/output.json
@@ -1,0 +1,34 @@
+{
+  "data": {
+    "allHeroesWithError": [
+      {
+        "name": "Iron Man",
+        "primaryLocation": "Los Angeles, CA"
+      },
+      null,
+      {
+        "name": "Wolverine",
+        "primaryLocation": "Unknown"
+      },
+      {
+        "name": "Spider Man",
+        "primaryLocation": "New York, NY"
+      }
+    ]
+  },
+  "errors": [
+    {
+      "locations": [
+        {
+          "line": 2,
+          "column": 5,
+          "sourceName": null
+        }
+      ],
+      "message": "Failed to find one or more heroes",
+      "errorType": null,
+      "extensions": null,
+      "path": null
+    }
+  ]
+}

--- a/tck/src/main/resources/tests/ex_partialResultsInGraphQLException/test.properties
+++ b/tck/src/main/resources/tests/ex_partialResultsInGraphQLException/test.properties
@@ -1,0 +1,4 @@
+# Tests the following exception handling behavior:
+# * Partial results passed in a GraphQLException are returned in addition to the expected error message
+ignore=false
+priority=200

--- a/tck/src/main/resources/tests/ex_partialResultsInGraphQLExceptionSubclass/input.graphql
+++ b/tck/src/main/resources/tests/ex_partialResultsInGraphQLExceptionSubclass/input.graphql
@@ -1,0 +1,6 @@
+query allHeroesWithSpecificError {
+    allHeroesWithSpecificError {
+        name
+        primaryLocation
+    }
+}

--- a/tck/src/main/resources/tests/ex_partialResultsInGraphQLExceptionSubclass/output.json
+++ b/tck/src/main/resources/tests/ex_partialResultsInGraphQLExceptionSubclass/output.json
@@ -1,0 +1,33 @@
+{
+  "data": {
+    "allHeroesWithSpecificError": [
+      {
+        "name": "Iron Man",
+        "primaryLocation": "Los Angeles, CA"
+      },
+      {
+        "name": "Starlord",
+        "primaryLocation": "Outer Space"
+      },
+      {
+        "name": "Wolverine",
+        "primaryLocation": "Unknown"
+      }
+    ]
+  },
+  "errors": [
+    {
+      "locations": [
+        {
+          "line": 2,
+          "column": 5,
+          "sourceName": null
+        }
+      ],
+      "message": "Failed to find one or more heroes",
+      "errorType": null,
+      "extensions": null,
+      "path": null
+    }
+  ]
+}

--- a/tck/src/main/resources/tests/ex_partialResultsInGraphQLExceptionSubclass/test.properties
+++ b/tck/src/main/resources/tests/ex_partialResultsInGraphQLExceptionSubclass/test.properties
@@ -1,0 +1,4 @@
+# Tests the following exception handling behavior:
+# * Partial results passed in a subclass of GraphQLException are returned in addition to the expected error message
+ignore=false
+priority=200

--- a/tck/src/main/resources/tests/ex_unknownHeroNonGraphQLException/output.json
+++ b/tck/src/main/resources/tests/ex_unknownHeroNonGraphQLException/output.json
@@ -1,19 +1,18 @@
 {
-  "data": {
-    "superHero": null
-  },
-  "errors": [
-    {
-      "message": "Unexpected failure in the system. Jarvis is working to fix it.",
-      "locations": [
+    "data": {
+        "superHero": null
+    },
+    "errors": [
         {
-          "line": 2,
-          "column": 3,
-          "sourceName": null
+            "message": "Unexpected failure in the system. Jarvis is working to fix it.",
+            "locations": [
+                {
+                    "line": 2,
+                    "column": 3,
+                    "sourceName": null
+                }
+            ],
+            "path": null
         }
-      ],
-      "path": null,
-      "extensions": null
-    }
-  ]
+    ]
 }


### PR DESCRIPTION
This pull request adds the ability for users to send partial results from a single query/mutation method by passing the results in the GraphQLException (or subclass exception) throw from the query/mutation method.

It includes a new property on the `GraphQLException` class, new spec text documenting the behavior, and new and updated TCK tests.

For this to work in OpenLiberty and presumably other implementations, I opened GraphQL-SPQR PR [302](https://github.com/leangen/graphql-spqr/pull/302).

This resolves issue #21.