### PR TITLE
Issue 55: Exclude EL API dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -103,6 +103,12 @@
                 <artifactId>cdi-api</artifactId>
                 <version>${cdi-api.version}</version>
                 <scope>provided</scope>
+                <exclusions>
+                    <exclusion>
+                        <groupId>javax.el</groupId>
+                        <artifactId>javax.el-api</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             
             <!-- Testing -->


### PR DESCRIPTION
Per eclipse/microprofile#56 this excludes the unnecessary EL API dependency brought in via the CDI dependency.  This resolves issue #55.