### PR TITLE
New runner profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -92,8 +92,6 @@
         <module>spec</module>
         <module>api</module>
         <module>tck</module>
-        <module>spqr</module> <!-- Only here until mp sqpr is available in maven central -->
-        <module>runner</module>
     </modules>
 
     <dependencyManagement>
@@ -356,6 +354,13 @@
                     </plugin>
                 </plugins>
             </build>
+        </profile>
+        <profile>
+            <id>runner</id>
+            <modules>
+                <module>spqr</module> <!-- Only here until mp sqpr is available in maven central -->
+                <module>runner</module>
+            </modules>
         </profile>
     </profiles>
 </project>


### PR DESCRIPTION
The `spqr` and `runner` modules are failing in the release builds because they use unpublished SPQR dependencies.  Since we don't want to release anything from these modules anyway, I think it makes sense to separate them into their own profile.  

With these changes, we can build the API, spec, and TCK using `mvn clean install` - and release will build/publish these same modules.  In order to use the `spqr` and `runner` modules, you would need to do `mvn clean install -Prunner`.