### PR TITLE
Issue 68: @NonNull API

### DIFF
--- a/api/src/main/java/org/eclipse/microprofile/graphql/NonNull.java
+++ b/api/src/main/java/org/eclipse/microprofile/graphql/NonNull.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.eclipse.microprofile.graphql;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Specifies that the GraphQL type and/or input type represented by the Java
+ * field this annotation is applied to must be marked as non-null in the schema.
+ * <br>
+ * <br>
+ * For example, a user might annotate a class' property as such:
+ * 
+ * <pre>
+ * {@literal @}Type(name = "Starship", description = "A starship in StarWars")
+ * {@literal @}InputType(name = "StarshipInput", description = "Input type for a starship")
+ * public class Starship {
+ *     private String id;
+ *     {@literal @}NonNull
+ *     private String name;
+ *     private float length;
+ *
+ *     // getters/setters...
+ * }
+ * </pre>
+ *
+ * Schema generation of this would result in a stanza such as:
+ * 
+ * <pre>
+ * # A starship from Starwars
+ * type Starship {
+ *   id: String
+ *   name: String!
+ *   length: Float!
+ * }
+ *
+ * # Input type for a starship
+ * input StarshipInput {
+ *   # uuid of a new Starship
+ *   id: String
+ *   name: String!
+ *   length: Float!
+ * }
+ * </pre>
+ * 
+ * <br>
+ * <br>
+ * Note that all primitive fields/properties are automatically considered non-null unless they are also annotated with
+ * a <code>DefaultValue</code> annotation.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.FIELD, ElementType.METHOD})
+@Documented
+public @interface NonNull {
+}

--- a/spec/src/main/asciidoc/entities.asciidoc
+++ b/spec/src/main/asciidoc/entities.asciidoc
@@ -154,3 +154,25 @@ If the `@Ignore` annotation is placed on the field itself, then the field will b
 output types in the generated schema.  If the annotation is only placed on the "getter" method, then it will only be
 excluded from the input type.  If the annotation is only placed on the "setter" method, then it will only be excluded
 from the output type.
+
+=== Non-nullable fields
+
+The GraphQL specification states that fields may be marked as non-nullable - usually the field's type is marked with an
+exclamation point to indicate that null values are not allowed.  Non-nullable fields may be present on types and input
+types, providing the client with the proper expectations for providing an input type and that they can expect a non-null
+value on the return type. If the client sends a null value for a required (non-nullable) field or sends an entity with
+the required (non-nullable) field unspecified, the implementation should respond with a validation error. Likewise, the
+implementation should return an error if a null is returned for a required (non-nullable) field from the application
+code.
+
+By default all GraphQL fields generated from Java primitive properties (`boolean`, `int`, `double`, etc.) will
+automatically be marked as required.  If a Java primitive property has a `@DefaultValue` annotation value, then null is
+allowed, but the implementation is expected to convert the value to be the default value specified in the annotation.
+
+By default, all GraphQL fields generated from non-primitive properties will be considered nullable. A user may specify
+that a field is required/non-nullable by adding the `@NotNull` annotation. This annotation may be applied to an entity's
+getter method, setter method or field. The placement will determine whether it applies to the type, input type or both,
+respectively.
+
+The implementation should ignore a `@NotNull` annotation when it is on the same field or setter method that also
+contains `@DefaultValue` annotation, as the "null" value would result in the default value being used.

--- a/spec/src/main/asciidoc/entities.asciidoc
+++ b/spec/src/main/asciidoc/entities.asciidoc
@@ -176,3 +176,8 @@ respectively.
 
 The implementation should ignore a `@NotNull` annotation when it is on the same field or setter method that also
 contains `@DefaultValue` annotation, as the "null" value would result in the default value being used.
+
+One drawback to using non-nullable fields is that if there is an error loading a child field, that error could propagate
+itself up causing the field to be null - and since this is itself an error condition, the implementation must return
+the non-null field error, which means that the implementation would not be able to send partial results for other child
+fields.

--- a/tck/src/main/java/org/eclipse/microprofile/graphql/tck/apps/superhero/api/HeroFinder.java
+++ b/tck/src/main/java/org/eclipse/microprofile/graphql/tck/apps/superhero/api/HeroFinder.java
@@ -114,8 +114,7 @@ public class HeroFinder {
                                    @Argument("team") String teamName)
                                    throws UnknownTeamException {
         LOG.info("removeHeroFromTeam invoked");
-        return heroDB.getTeam(teamName)
-                .removeMembers( heroDB.getHero(heroName) );
+        return heroDB.removeHeroesFromTeam(heroDB.getTeam(teamName), heroDB.getHero(heroName));
     }
 
     @Mutation
@@ -237,5 +236,21 @@ public class HeroFinder {
             }
         }
         return null;
+    }
+
+    @Mutation
+    public Team createNewTeam(@Argument("newTeam") Team newTeam) {
+        List<SuperHero> members = newTeam.getMembers();
+        Team team = heroDB.createNewTeam(newTeam.getName());
+        if (members != null && members.size() > 0) {
+            team.setMembers(members);
+        }
+        team.setRivalTeam(newTeam.getRivalTeam());
+        return team;
+    }
+
+    @Mutation
+    public Team removeTeam(@Argument("teamName") String teamName) throws UnknownTeamException {
+        return heroDB.removeTeam(teamName);
     }
 }

--- a/tck/src/main/java/org/eclipse/microprofile/graphql/tck/apps/superhero/db/HeroDatabase.java
+++ b/tck/src/main/java/org/eclipse/microprofile/graphql/tck/apps/superhero/db/HeroDatabase.java
@@ -93,9 +93,7 @@ public class HeroDatabase {
                 Team team = iter.next();
                 Team existingTeam = allTeams.get(team.getName());
                 if (existingTeam == null) {
-                    existingTeam = new Team();
-                    existingTeam.setName(team.getName());
-                    allTeams.put(team.getName(), existingTeam);
+                    existingTeam = createNewTeam(team.getName());
                 }
                 iter.set(existingTeam);
                 List<SuperHero> members = existingTeam.getMembers();
@@ -117,6 +115,37 @@ public class HeroDatabase {
             team.removeMembers(hero);
         }
         return hero;
+    }
+
+    public Team createNewTeam(String teamName, SuperHero...initialMembers) {
+        Team newTeam = new Team();
+        newTeam.setName(teamName);
+        newTeam.addMembers(initialMembers);
+        allTeams.put(teamName, newTeam);
+        return newTeam;
+    }
+
+    public Team removeHeroesFromTeam(Team team, SuperHero... heroes) {
+        team.removeMembers(heroes);
+        for (SuperHero hero : heroes) {
+            List<Team> teamAffiliations = hero.getTeamAffiliations();
+            if (teamAffiliations != null) {
+                teamAffiliations.remove(team);
+            }
+        }
+        return team;
+    }
+
+    public Team removeHeroesFromTeam(Team team, Collection<SuperHero> heroes) {
+        return removeHeroesFromTeam(team, heroes.toArray(new SuperHero[]{}));
+    }
+
+    public Team removeTeam(String teamName) throws UnknownTeamException {
+        Team team = allTeams.remove(teamName);
+        if (team == null) {
+            throw new UnknownTeamException(teamName);
+        }
+        return removeHeroesFromTeam(team, allHeroes.values());
     }
 
     private static String getInitalJson() {

--- a/tck/src/main/java/org/eclipse/microprofile/graphql/tck/apps/superhero/model/Item.java
+++ b/tck/src/main/java/org/eclipse/microprofile/graphql/tck/apps/superhero/model/Item.java
@@ -17,16 +17,20 @@ package org.eclipse.microprofile.graphql.tck.apps.superhero.model;
 
 import java.util.Collection;
 
+import org.eclipse.microprofile.graphql.DefaultValue;
 import org.eclipse.microprofile.graphql.Description;
 import org.eclipse.microprofile.graphql.Id;
 import org.eclipse.microprofile.graphql.Ignore;
+import org.eclipse.microprofile.graphql.NonNull;
 
 @Description("Something of use to a super hero")
 public class Item {
 
     @Id
     private long id;
+    @NonNull
     private String name;
+    private String description;
     private int powerLevel;
     private double height;
     private float weight;
@@ -130,5 +134,15 @@ public class Item {
     @Ignore
     public void setArtificialIntelligenceRating(boolean artificialIntelligenceRating) {
         this.artificialIntelligenceRating = artificialIntelligenceRating;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    @NonNull
+    @DefaultValue("An unidentified item")
+    public void setDescription(String description) {
+        this.description = description;
     }
 }

--- a/tck/src/main/java/org/eclipse/microprofile/graphql/tck/apps/superhero/model/SuperHero.java
+++ b/tck/src/main/java/org/eclipse/microprofile/graphql/tck/apps/superhero/model/SuperHero.java
@@ -27,7 +27,9 @@ import javax.json.bind.annotation.JsonbProperty;
 import javax.json.bind.annotation.JsonbTransient;
 
 import org.eclipse.microprofile.graphql.Description;
+import org.eclipse.microprofile.graphql.NonNull;
 import org.eclipse.microprofile.graphql.Query;
+
 
 public class SuperHero {
     private List<Team> teamAffiliations;
@@ -105,6 +107,7 @@ public class SuperHero {
         this.primaryLocation = primaryLocation;
     }
 
+    @NonNull
     public void setName(String name) {
         this.name = name;
     }

--- a/tck/src/main/java/org/eclipse/microprofile/graphql/tck/apps/superhero/model/Team.java
+++ b/tck/src/main/java/org/eclipse/microprofile/graphql/tck/apps/superhero/model/Team.java
@@ -15,7 +15,10 @@
  */
 package org.eclipse.microprofile.graphql.tck.apps.superhero.model;
 
+import java.util.ArrayList;
 import java.util.List;
+
+import org.eclipse.microprofile.graphql.NonNull;
 
 public class Team {
 
@@ -32,6 +35,7 @@ public class Team {
         this.members = members;
     }
 
+    @NonNull
     public String getName() {
         return name;
     }
@@ -49,14 +53,19 @@ public class Team {
     }
 
     public Team addMembers(SuperHero...heroes) {
+        if (members == null) {
+            members = new ArrayList<>();
+        }
         for (SuperHero hero : heroes) {
             members.add(hero);
         }
         return this;
     }
     public Team removeMembers(SuperHero...heroes) {
-        for (SuperHero hero : heroes) {
-            members.remove(hero);
+        if (members != null) {
+            for (SuperHero hero : heroes) {
+                members.remove(hero);
+            }
         }
         return this;
     }

--- a/tck/src/main/resources/tests/createNewHeroWithVariables/input.graphql
+++ b/tck/src/main/resources/tests/createNewHeroWithVariables/input.graphql
@@ -1,4 +1,4 @@
-mutation createNewHeroWithVariables($name: String, $realName: String, $primaryLocation: String, $superPowers: [String], $teamAffiliations: [TeamInput]){
+mutation createNewHeroWithVariables($name: String!, $realName: String, $primaryLocation: String, $superPowers: [String], $teamAffiliations: [TeamInput]){
     createNewHero(hero:{
         name: $name
         realName: $realName

--- a/tck/src/main/resources/tests/createNewNullNamedHero/input.graphql
+++ b/tck/src/main/resources/tests/createNewNullNamedHero/input.graphql
@@ -1,0 +1,11 @@
+mutation createNullNamedHero {
+  createNewHero  (hero: {
+    realName: "John Smith"
+    name: null
+  }) {
+    currentLocation
+    name
+    primaryLocation
+    realName
+  }
+}

--- a/tck/src/main/resources/tests/createNewNullNamedHero/output.json
+++ b/tck/src/main/resources/tests/createNewNullNamedHero/output.json
@@ -1,0 +1,23 @@
+{
+  "data": null,
+  "errors": [
+    {
+      "message": "Validation error of type WrongType: argument 'hero.name' with value 'NullValue{}' must not be null @ 'createNewHero'",
+      "locations": [
+        {
+          "line": 2,
+          "column": 19,
+          "sourceName": null
+        }
+      ],
+      "description": "argument 'hero.name' with value 'NullValue{}' must not be null",
+      "validationErrorType": "WrongType",
+      "queryPath": [
+        "createNewHero"
+      ],
+      "errorType": "ValidationError",
+      "path": null,
+      "extensions": null
+    }
+  ]
+}

--- a/tck/src/main/resources/tests/createNewNullNamedHero/test.properties
+++ b/tck/src/main/resources/tests/createNewNullNamedHero/test.properties
@@ -1,0 +1,3 @@
+# This tests that the implementation responds with the correct error when the client passes null for a required (nonnull) field
+ignore=false
+priority=200

--- a/tck/src/main/resources/tests/createNewNullNamedTeam/cleanup.graphql
+++ b/tck/src/main/resources/tests/createNewNullNamedTeam/cleanup.graphql
@@ -1,0 +1,7 @@
+mutation removeTeam {
+  removeTeam(teamName: null) {
+    members {
+      name
+    }
+  }
+}

--- a/tck/src/main/resources/tests/createNewNullNamedTeam/input.graphql
+++ b/tck/src/main/resources/tests/createNewNullNamedTeam/input.graphql
@@ -1,0 +1,10 @@
+mutation createTeamWithNullName {
+  createNewTeam(newTeam: {
+    name: null
+  }) {
+    name
+    members {
+      name
+    }
+  }
+}

--- a/tck/src/main/resources/tests/createNewNullNamedTeam/output.json
+++ b/tck/src/main/resources/tests/createNewNullNamedTeam/output.json
@@ -1,0 +1,17 @@
+{
+  "data": {
+    "createNewTeam": null
+  },
+  "errors": [
+    {
+      "message": "Cannot return null for non-nullable type: 'String' within parent 'Team' (/createNewTeam/name)",
+      "path": [
+        "createNewTeam",
+        "name"
+      ],
+      "locations": null,
+      "errorType": "DataFetchingException",
+      "extensions": null
+    }
+  ]
+}

--- a/tck/src/main/resources/tests/createNewNullNamedTeam/test.properties
+++ b/tck/src/main/resources/tests/createNewNullNamedTeam/test.properties
@@ -1,0 +1,4 @@
+# This test creates a team with null name (allowed by schema), but then tries to view the team with name (not allowed,
+# because the name field is non-nullable in the output type), so it expects an error message indicating such.
+ignore=false
+priority=200

--- a/tck/src/main/resources/tests/createNewUnnamedHero/input.graphql
+++ b/tck/src/main/resources/tests/createNewUnnamedHero/input.graphql
@@ -1,0 +1,10 @@
+mutation createUnnamedHero {
+  createNewHero  (hero: {
+    realName: "John Smith"
+  }) {
+    currentLocation
+    name
+    primaryLocation
+    realName
+  }
+}

--- a/tck/src/main/resources/tests/createNewUnnamedHero/output.json
+++ b/tck/src/main/resources/tests/createNewUnnamedHero/output.json
@@ -1,0 +1,23 @@
+{
+  "data": null,
+  "errors": [
+    {
+      "message": "Validation error of type WrongType: argument 'hero' with value 'ObjectValue{objectFields=[ObjectField{name='realName', value=StringValue{value='John Smith'}}]}' is missing required fields '[name]' @ 'createNewHero'",
+      "locations": [
+        {
+          "line": 2,
+          "column": 19,
+          "sourceName": null
+        }
+      ],
+      "description": "argument 'hero' with value 'ObjectValue{objectFields=[ObjectField{name='realName', value=StringValue{value='John Smith'}}]}' is missing required fields '[name]'",
+      "validationErrorType": "WrongType",
+      "queryPath": [
+        "createNewHero"
+      ],
+      "errorType": "ValidationError",
+      "path": null,
+      "extensions": null
+    }
+  ]
+}

--- a/tck/src/main/resources/tests/createNewUnnamedHero/test.properties
+++ b/tck/src/main/resources/tests/createNewUnnamedHero/test.properties
@@ -1,0 +1,3 @@
+# This tests that the implementation responds with the correct error when the client fails to provide a required (nonnull) field
+ignore=false
+priority=200


### PR DESCRIPTION
Spec text, new API annotation, and TCK tests for specifying if fields can be null or not.

Per discussion in Issue #68, all fields with a `@DefaultValue` annotation are nullable.  All primitive fields (without a `@DefaultValue`) are non-nullable.  All other fields are nullable unless the `@NonNull` annotation is present.

When both the `@DefaultValue` and `@NonNull` annotation are on the same method, the `@DefaultValue` annotation wins, and the field is nullable (thus using the default value). 

Resolves #68 