### PR TITLE
Issue 44 and 72: `@Description` API

### DIFF
--- a/api/src/main/java/org/eclipse/microprofile/graphql/Argument.java
+++ b/api/src/main/java/org/eclipse/microprofile/graphql/Argument.java
@@ -23,21 +23,25 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Controls the mapping of a method's parameter to an argument of a GraphQL operation (query/mutation/subscription).
- * <br><br>
+ * Controls the mapping of a method's parameter to an argument of a GraphQL
+ * operation (query/mutation/subscription). <br>
+ * <br>
  * For example, a user might annotate a method's parameter as such:
+ * 
  * <pre>
  * public class CharacterService {
- *     {@literal @}Query(value = "searchByName",
- *                 description = "Search characters by name")
+ *     {@literal @}Query("searchByName")
  *     public List{@literal <}Character{@literal >} getByName(
- *                      {@literal @}Argument(value = "name", defaultValue = "Han Solo", description = "Name to search for") String name) {
+ *                      {@literal @}Argument("name")
+ *                      {@literal @}DefaultValue("Han Solo")
+ *                      {@literal @}Description("Name to search for") String name) {
  *         //...
  *     }
  * }
  * </pre>
  *
  * Schema generation of this would result in a stanza such as:
+ * 
  * <pre>
  * type Query {
  *         # Search characters by name
@@ -55,10 +59,4 @@ public @interface Argument {
      * @return the name to use for the GraphQL argument.
      */
     String value();
-
-    /**
-     * @return the textual description of the GraphQL argument to be included as a comment in the schema.
-     */
-    String description() default "";
-
 }

--- a/api/src/main/java/org/eclipse/microprofile/graphql/DefaultValue.java
+++ b/api/src/main/java/org/eclipse/microprofile/graphql/DefaultValue.java
@@ -23,15 +23,18 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Controls the mapping of a method's parameter to an argument of a GraphQL operation (query/mutation/subscription).
- * <br><br>
+ * Controls the mapping of a method's parameter to an argument of a GraphQL
+ * operation (query/mutation/subscription). <br>
+ * <br>
  * For example, a user might annotate a method's parameter as such:
+ * 
  * <pre>
  * public class CharacterService {
- *     {@literal @}Query(value = "searchByName",
- *                 description = "Search characters by name")
+ *     {@literal @}Query("searchByName"),
+ *     {@literal @}Description("Search characters by name")
  *     public List{@literal <}Character{@literal >} getByName(
- *                      {@literal @}Argument(name = "name", description = "Name to search for")
+ *                       {@literal @}Argument("name")
+ *                       {@literal @}Description("Name to search for")
  *                       {@literal @}DefaultValue("Han Solo")
  *                       String name) {
  *         //...
@@ -40,6 +43,7 @@ import java.lang.annotation.Target;
  * </pre>
  *
  * Schema generation of this would result in a stanza such as:
+ * 
  * <pre>
  * type Query {
  *         # Search characters by name

--- a/api/src/main/java/org/eclipse/microprofile/graphql/Deprecated.java
+++ b/api/src/main/java/org/eclipse/microprofile/graphql/Deprecated.java
@@ -23,12 +23,13 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Marks a field/method as being deprecated, with a reason. 
- * You should also be able to use java.lang.Deprecated, but then you can not provide a reason
- * <br><br>
+ * Marks a field/method as being deprecated, with a reason. You should also be
+ * able to use java.lang.Deprecated, but then you can not provide a reason <br>
+ * <br>
  * For example, a user might annotate a method as such:
+ * 
  * <pre>
- * {@literal @}InputType(name = "StarshipInput", description = "Input type for a starship")
+ * {@literal @}InputType("StarshipInput")
  * public class Starship {
  *     private String id;
  *     {@literal @}Deprecated("Field is deprecated!")
@@ -40,6 +41,7 @@ import java.lang.annotation.Target;
  * </pre>
  *
  * Schema generation of this would result in a stanza such as:
+ * 
  * <pre>
  * type Starship {
  *   id: String

--- a/api/src/main/java/org/eclipse/microprofile/graphql/Description.java
+++ b/api/src/main/java/org/eclipse/microprofile/graphql/Description.java
@@ -23,37 +23,42 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * To customize the appearance's order of input fields in documentation. No effect on the actual GraphQL schema.
- * <br><br>
- * For example, a user might annotate a class as such:
+ * Sets the description in the GraphQL schema for the target field, type,
+ * parameter, etc. <br>
+ * <br>
+ * For example, a user might annotate a type and field as such:
+ * 
  * <pre>
- * {@literal @}InputType("StarshipInput")
- * {@literal @}InputFieldsOrder({"name", "id", "length"})
+ * {@literal @}Description("Vehicle for traveling between star systems")
  * public class Starship {
  *     private String id;
- *     private String name;
  *     private float length;
+ *     {@literal @}Description("Name of a particular starship, not it's class - i.e. \"Millenium Falcon\"")
+ *     private String name;
  *
  *     // getters/setters...
  * }
  * </pre>
  *
  * Schema generation of this would result in a stanza such as:
+ * 
  * <pre>
- * input Starship {
+ * {@literal #}Vehicle for traveling between star systems
+ * type Starship {
  *   id: String
- *   name: String
  *   length: Float
+ *   {@literal #}Name of a particular starship, not it's class - i.e. "Millenium Falcon"
+ *   name: String
  * }
  * </pre>
  */
+@Target({ElementType.PARAMETER,ElementType.METHOD,ElementType.FIELD, ElementType.TYPE})
 @Retention(RetentionPolicy.RUNTIME)
-@Target({ElementType.TYPE})
 @Documented
-public @interface InputFieldsOrder {
+public @interface Description {
 
     /**
-     * @return an ordered list of GraphQL input fields' names.
+     * @return the description text.
      */
-    String[] value() default {};
+    String value() default "";
 }

--- a/api/src/main/java/org/eclipse/microprofile/graphql/FieldsOrder.java
+++ b/api/src/main/java/org/eclipse/microprofile/graphql/FieldsOrder.java
@@ -23,11 +23,14 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * To customize the appearance's order of fields in documentation. No effect on the actual GraphQL schema.
- * <br><br>
+ * To customize the appearance's order of fields in documentation. No effect on
+ * the actual GraphQL schema. <br>
+ * <br>
  * For example, a user might annotate a class as such:
+ * 
  * <pre>
- * {@literal @}Type(name = "Starship", description = "Type for a starship")
+ * {@literal @}Type("Starship")
+ * {@literal @}Description("Type for a starship")
  * {@literal @}FieldsOrder({"name", "id", "length"})
  * public class Starship {
  *     private String id;
@@ -39,6 +42,7 @@ import java.lang.annotation.Target;
  * </pre>
  *
  * Schema generation of this would result in a stanza such as:
+ * 
  * <pre>
  * # Type for a starship
  * type Starship {

--- a/api/src/main/java/org/eclipse/microprofile/graphql/Ignore.java
+++ b/api/src/main/java/org/eclipse/microprofile/graphql/Ignore.java
@@ -23,19 +23,26 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Excludes an otherwise mapped element. Mostly useful to e.g. mark a field as excluded in the GraphQL input type only.
- * <br><br>
- * The behavior is different depending on where <b>@Ignore</b> annotation is placed:
- *  <ul>
- *      <li><b>On field</b>: Field is ignored in both graphql type and input type.</li>
- *      <li><b>On getter</b>: Field is ignored in the graphql type.</li>
- *      <li><b>On setter</b>: Field is ignored in the graphql input type.</li>
- *  </ul>
- * <br><br>
- * For example, a user might annotate a class' properties and/or getters/setters as such:
+ * Excludes an otherwise mapped element. Mostly useful to e.g. mark a field as
+ * excluded in the GraphQL input type only. <br>
+ * <br>
+ * The behavior is different depending on where <b>@Ignore</b> annotation is
+ * placed:
+ * <ul>
+ * <li><b>On field</b>: Field is ignored in both graphql type and input
+ * type.</li>
+ * <li><b>On getter</b>: Field is ignored in the graphql type.</li>
+ * <li><b>On setter</b>: Field is ignored in the graphql input type.</li>
+ * </ul>
+ * <br>
+ * <br>
+ * For example, a user might annotate a class' properties and/or getters/setters
+ * as such:
+ * 
  * <pre>
- * {@literal @}Type(name = "Starship", description = "A starship in StarWars")
- * {@literal @}InputType(name = "StarshipInput", description = "Input object for a starship")
+ * {@literal @}Type("Starship")
+ * {@literal @}InputType("StarshipInput")
+ * {@literal @}Description("A starship in Star Wars")
  * public class Starship {
  *     private String id;
  *     private String name;
@@ -59,19 +66,20 @@ import java.lang.annotation.Target;
  * </pre>
  *
  * Schema generation of this would result in a stanza such as:
+ * 
  * <pre>
- * # A starship from Starwars
+ * # A starship in Star Wars
  * type Starship {
  *   id: String
- *   name: String
  *   length: Float
+ *   name: String
  * }
  *
- * # Input object for a starship
- * input Starship {
+ * # A starship in Star Wars
+ * input StarshipInput {
  *   id: String
- *   name: String
  *   mass: Float
+ *   name: String
  * }
  * </pre>
  */

--- a/api/src/main/java/org/eclipse/microprofile/graphql/InputField.java
+++ b/api/src/main/java/org/eclipse/microprofile/graphql/InputField.java
@@ -24,13 +24,17 @@ import java.lang.annotation.Target;
 
 /**
  * Controls the mapping from a class' property to a GraphQL input type's field.
- * <br><br>
+ * <br>
+ * <br>
  * For example, a user might annotate a class' property as such:
+ * 
  * <pre>
- * {@literal @}Type(name = "Starship", description = "A starship in StarWars")
- * {@literal @}InputType(name = "StarshipInput", description = "Input type for a starship")
+ * {@literal @}Type("Starship")
+ * {@literal @}InputType("StarshipInput")
+ * {@literal @}Description("A starship in Star Wars")
  * public class Starship {
- *     {@literal @}InputField(value = "uuid", description = "uuid of a new Starship")
+ *     {@literal @}InputField("uuid")
+ *     {@literal @}Description("uuid of a new Starship")
  *     private String id;
  *     private String name;
  *     private float length;
@@ -40,15 +44,9 @@ import java.lang.annotation.Target;
  * </pre>
  *
  * Schema generation of this would result in a stanza such as:
+ * 
  * <pre>
- * # A starship from Starwars
- * type Starship {
- *   id: String
- *   name: String
- *   length: Float
- * }
- *
- * # Input type for a starship
+ * # A starship in Star Wars
  * input Starship {
  *   # uuid of a new Starship
  *   uuid: String
@@ -66,9 +64,4 @@ public @interface InputField {
      * @return the name to use for the input field.
      */
     String value();
-
-    /**
-     * @return the textual description of the GraphQL input field to be included as a comment in the schema.
-     */
-    String description() default "";
 }

--- a/api/src/main/java/org/eclipse/microprofile/graphql/InputType.java
+++ b/api/src/main/java/org/eclipse/microprofile/graphql/InputType.java
@@ -23,11 +23,13 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Maps the annotated class to a GraphQL input type.
- * <br><br>
+ * Maps the annotated class to a GraphQL input type. <br>
+ * <br>
  * For example, a user might annotate a class as such:
+ * 
  * <pre>
- * {@literal @}InputType(name = "StarshipInput", description = "Input type for a starship")
+ * {@literal @}InputType("StarshipInput")
+ * {@literal @}Description("Input type for a starship")
  * public class Starship {
  *     private String id;
  *     private String name;
@@ -38,9 +40,10 @@ import java.lang.annotation.Target;
  * </pre>
  *
  * Schema generation of this would result in a stanza such as:
+ * 
  * <pre>
  * # Input type for a starship
- * input Starship {
+ * input StarshipInput {
  *   id: String
  *   name: String
  *   length: Float
@@ -56,9 +59,4 @@ public @interface InputType {
      * @return the name of the GraphQL input type.
      */
     String value() default "";
-
-    /**
-     * @return the textual description of the GraphQL input type to be included as a comment in the schema.
-     */
-    String description() default "";
 }

--- a/api/src/main/java/org/eclipse/microprofile/graphql/Mutation.java
+++ b/api/src/main/java/org/eclipse/microprofile/graphql/Mutation.java
@@ -23,12 +23,15 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Specifies that the annotated method provides the implementation (ie. the resolver) for a GraphQL mutation.
- * <br><br>
+ * Specifies that the annotated method provides the implementation (ie. the
+ * resolver) for a GraphQL mutation. <br>
+ * <br>
  * For example, a user might annotate a method as such:
+ * 
  * <pre>
  * public class CharacterService {
- *     {@literal @}Mutation(name = "addCharacter", description = "Save a new character")
+ *     {@literal @}Mutation("addCharacter")
+ *     {@literal @}Description("Save a new character")
  *     public Character save(Character character) {
  *         //...
  *     }
@@ -36,6 +39,7 @@ import java.lang.annotation.Target;
  * </pre>
  *
  * Schema generation of this would result in a stanza such as:
+ * 
  * <pre>
  * type Mutation {
  *     # Save a new character
@@ -52,9 +56,4 @@ public @interface Mutation {
      * @return the name of the GraphQL mutation.
      */
     String value() default "";
-
-    /**
-     * @return the textual description of the mutation to be included as a comment in the schema.
-     */
-    String description() default "";
 }

--- a/api/src/main/java/org/eclipse/microprofile/graphql/Query.java
+++ b/api/src/main/java/org/eclipse/microprofile/graphql/Query.java
@@ -23,13 +23,15 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Specifies that the annotated method provides the implementation (ie. the resolver) for a GraphQL query.
- * <br><br>
+ * Specifies that the annotated method provides the implementation (ie. the
+ * resolver) for a GraphQL query. <br>
+ * <br>
  * For example, a user might annotate a method as such:
+ * 
  * <pre>
  * public class CharacterService {
- *     {@literal @}Query(value = "friendsOf",
- *                 description = "Returns all the friends of a character")
+ *     {@literal @}Query("friendsOf")
+ *     {@literal @}Description("Returns all the friends of a character")
  *     public List{@literal <}Character{@literal >} getFriendsOf(Character character) {
  *         //...
  *     }
@@ -37,6 +39,7 @@ import java.lang.annotation.Target;
  * </pre>
  *
  * Schema generation of this would result in a stanza such as:
+ * 
  * <pre>
  * type Query {
  *    # Returns all the friends of a character
@@ -52,9 +55,4 @@ public @interface Query {
      * @return the name to use for the query. If empty, annotated method's name is used.
      */
     String value() default "";
-
-    /**
-     * @return the textual description of the query to be included as a comment in the schema.
-     */
-    String description() default "";
 }

--- a/api/src/main/java/org/eclipse/microprofile/graphql/Source.java
+++ b/api/src/main/java/org/eclipse/microprofile/graphql/Source.java
@@ -23,39 +23,49 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Extends a GraphQL type by adding an externally defined field, effectively enabling a graph to be assembled.
- * <br><br>
- * The GraphQL type which is extended is the GraphQL type corresponding to the Java type of the annotated method parameter.
- * <br><br>
- * The added field type can be a scalar or another GraphQL type, it's inferred from the method return type.
- * <br><br>
- * At runtime, injects the concerned source object (which type is the extended GraphQL type),
- * thus allowing to use fields from it to resolve the added field.
- * <br><br>
- * Optionally, specifies the name and description of the added field in the extended GraphQL type.
- * By default, the name of the added field is the name of the method.
+ * Extends a GraphQL type by adding an externally defined field, effectively
+ * enabling a graph to be assembled. <br>
+ * <br>
+ * The GraphQL type which is extended is the GraphQL type corresponding to the
+ * Java type of the annotated method parameter. <br>
+ * <br>
+ * The added field type can be a scalar or another GraphQL type, it's inferred
+ * from the method return type. <br>
+ * <br>
+ * At runtime, injects the concerned source object (which type is the extended
+ * GraphQL type), thus allowing to use fields from it to resolve the added
+ * field. <br>
+ * <br>
+ * Optionally, specifies the name and description of the added field in the
+ * extended GraphQL type. By default, the name of the added field is the name of
+ * the method.
  *
- * <br><br>
+ * <br>
+ * <br>
  * For example, a user might annotate a method's parameter as such:
+ * 
  * <pre>
  * public class CharacterService {
  *      {@literal @}Inject TwitterService twitterService;
  *
- *     {@literal @}Query(value = "tweets", description = "Get the last tweets for a character")
+ *     {@literal @}Query(value = "tweets")
+ *     {@literal @}Description = "Get the last tweets for a character")
  *     public List{@literal <}Tweet{@literal >} tweets(
- *                          {@literal @}Source(fieldName = "tweetsForMe", description = "Get the last tweets for the character") Character character,
- *                          {@literal @}Argument(name = "last", description = "Number of last tweets to fetch") int last) {
+ *                          {@literal @}Source("tweetsForMe") {@literal @}Description("Get the last tweets for the character") Character character,
+ *                          {@literal @}Argument("last") {@literal @}Description = "Number of last tweets to fetch") int last) {
  *          return twitterService.search(character.getName(), last);
  *     }
  * }
  * </pre>
  * <p>
  * Schema generation of this would result in a stanza such as:
+ * 
  * <pre>
  * type Character {
  *    # Other fields ...
  *
  *    # Get the last tweets for the character
+ *    # last: Number of last tweets to fetch
  *    tweetsForMe(last: Int): [Tweet]
  * }
  * </pre>
@@ -68,9 +78,4 @@ public @interface Source {
      * @return the name of the added type in the extended GraphQL type.
      */
     String name() default "";
-
-    /**
-     * @return the textual description of the added field to be included as a comment in the schema.
-     */
-    String description() default "";
 }

--- a/api/src/main/java/org/eclipse/microprofile/graphql/Type.java
+++ b/api/src/main/java/org/eclipse/microprofile/graphql/Type.java
@@ -23,11 +23,13 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Maps of the annotated Java class to a GraphQL type.
- * <br><br>
+ * Maps of the annotated Java class to a GraphQL type. <br>
+ * <br>
  * For example, a user might annotate a class as such:
+ * 
  * <pre>
- * {@literal @}Type(value = "Starship", description = "A starship in StarWars")
+ * {@literal @}Type("Starship")
+ * {@literal @}Description("A starship in Star Wars")
  * public class Starship {
  *     private String id;
  *     private String name;
@@ -38,8 +40,9 @@ import java.lang.annotation.Target;
  * </pre>
  *
  * Schema generation of this would result in a stanza such as:
+ * 
  * <pre>
- * # A starship in StarWars
+ * # A starship in Star Wars
  * type Starship {
  *   id: String
  *   name: String
@@ -56,9 +59,4 @@ public @interface Type {
      * @return the name of the GraphQL type.
      */
     String value() default "";
-
-    /**
-     * @return the textual description of the GraphQL type to be included as a comment in the schema.
-     */
-    String description() default "";
 }

--- a/api/src/main/java/org/eclipse/microprofile/graphql/package-info.java
+++ b/api/src/main/java/org/eclipse/microprofile/graphql/package-info.java
@@ -20,15 +20,17 @@
 
 /**
  * APIs for building a code-first GraphQL endpoint, for example:
+ * 
  * <pre>
  * public class CharacterService {
- *     {@literal @}Query(value = "friendsOf",
- *                 description = "Returns all the friends of a character")
+ *     {@literal @}Query("friendsOf")
+ *     {@literal @}Description("Returns all the friends of a character")
  *     public List{@literal <}Character{@literal >} getFriendsOf(Character character) {
  *         // ... 
  *     }
  * }
  * </pre>
+ * 
  * @since 1.0
  */
 @org.osgi.annotation.versioning.Version("1.0")

--- a/api/src/test/java/org/eclipse/microprofile/graphql/ArgumentTest.java
+++ b/api/src/test/java/org/eclipse/microprofile/graphql/ArgumentTest.java
@@ -40,9 +40,11 @@ public class ArgumentTest {
             return name;
         }
 
-        @Query(value = "friendsOf", description = "Returns all the friends of a character")
+        @Query("friendsOf")
+        @Description("Returns all the friends of a character")
         public List<Character> getFriendsOf(
-                @Argument(value = "whomFriends", description = "Whom friends to fetch") Character character) {
+                @Argument("whomFriends")
+                @Description("Whom friends to fetch") Character character) {
             if (character.getName().equals("Han Solo")) {
                 return Collections.singletonList(new Character("Chewbacca"));
             }
@@ -52,8 +54,11 @@ public class ArgumentTest {
 
     @Test
     public void testArgumentAnnotationOnCharacterParameter() throws Exception {
-        Argument argument = (Argument)Character.class.getDeclaredMethod("getFriendsOf", Character.class).getParameterAnnotations()[0][0];
+        Argument argument = (Argument)Character.class.getDeclaredMethod("getFriendsOf", Character.class)
+                                                     .getParameterAnnotations()[0][0];
+        Description description = (Description) Character.class.getDeclaredMethod("getFriendsOf", Character.class)
+                                                               .getParameterAnnotations()[0][1];
         assertEquals(argument.value(), "whomFriends");
-        assertEquals(argument.description(), "Whom friends to fetch");
+        assertEquals(description.value(), "Whom friends to fetch");
     }
 }

--- a/api/src/test/java/org/eclipse/microprofile/graphql/DefaultValueTest.java
+++ b/api/src/test/java/org/eclipse/microprofile/graphql/DefaultValueTest.java
@@ -38,7 +38,7 @@ public class DefaultValueTest {
             return name;
         }
 
-        @Query(value = "friendsOf", description = "Returns all the friends of a character")
+        @Query("friendsOf")
         public List<Character> getFriendsOf(
                 @DefaultValue("Han Solo")
                         Character character) {

--- a/api/src/test/java/org/eclipse/microprofile/graphql/InputFieldTest.java
+++ b/api/src/test/java/org/eclipse/microprofile/graphql/InputFieldTest.java
@@ -29,7 +29,8 @@ public class InputFieldTest {
     @InputType()
     private static class Starship {
         private String id;
-        @InputField(value = "theName", description = "Name of the starship in StarshipInput type")
+        @InputField("theName")
+        @Description("Name of the starship in StarshipInput type")
         private String name;
         private float length;
     }
@@ -37,7 +38,8 @@ public class InputFieldTest {
     @Test
     public void testInputFieldAnnotationOnNameField() throws Exception {
         InputField inputField = Starship.class.getDeclaredField("name").getAnnotationsByType(InputField.class)[0];
+        Description description = Starship.class.getDeclaredField("name").getAnnotationsByType(Description.class)[0];
         assertEquals(inputField.value(),"theName");
-        assertEquals(inputField.description(),"Name of the starship in StarshipInput type");
+        assertEquals(description.value(),"Name of the starship in StarshipInput type");
     }
 }

--- a/api/src/test/java/org/eclipse/microprofile/graphql/InputTypeTest.java
+++ b/api/src/test/java/org/eclipse/microprofile/graphql/InputTypeTest.java
@@ -26,7 +26,8 @@ import static org.testng.Assert.assertEquals;
  */
 public class InputTypeTest {
 
-    @InputType(value = "StarshipInput", description = "StarshipInput type")
+    @InputType("StarshipInput")
+    @Description("StarshipInput type")
     @InputFieldsOrder({"name", "id", "length"})
     private static class Starship {
         private String id;
@@ -38,7 +39,8 @@ public class InputTypeTest {
     public void testInputTypeAnnotationOnStarshipClass() throws Exception {
         InputType inputType = Starship.class.getAnnotation(InputType.class);
         assertEquals(inputType.value(), "StarshipInput");
-        assertEquals(inputType.description(), "StarshipInput type");
+        Description description = Starship.class.getAnnotation(Description.class);
+        assertEquals(description.value(), "StarshipInput type");
 
         InputFieldsOrder inputFieldsOrder = Starship.class.getAnnotation(InputFieldsOrder.class);
         assertEquals(inputFieldsOrder.value(), new String[] {"name", "id", "length"});

--- a/api/src/test/java/org/eclipse/microprofile/graphql/MutationTest.java
+++ b/api/src/test/java/org/eclipse/microprofile/graphql/MutationTest.java
@@ -37,7 +37,8 @@ public class MutationTest {
             return name;
         }    
 
-        @Mutation(value = "save", description = "Save a character")
+        @Mutation("save")
+        @Description("Save a character")
         public Character saveCharacter(Character character) {
 
             return character;
@@ -48,6 +49,8 @@ public class MutationTest {
     public void testMutationAnnotationOnCharacterMethod() throws Exception {
         Mutation mutation = Character.class.getDeclaredMethod("saveCharacter", Character.class).getAnnotation(Mutation.class);
         assertEquals(mutation.value(), "save");
-        assertEquals(mutation.description(), "Save a character");
+        Description description = Character.class.getDeclaredMethod("saveCharacter", Character.class)
+                                                 .getAnnotation(Description.class);
+        assertEquals(description.value(), "Save a character");
     }
 }

--- a/api/src/test/java/org/eclipse/microprofile/graphql/QueryTest.java
+++ b/api/src/test/java/org/eclipse/microprofile/graphql/QueryTest.java
@@ -39,7 +39,8 @@ public class QueryTest {
             return name;
         }    
 
-        @Query(value = "friendsOf", description = "Returns all the friends of a character")
+        @Query("friendsOf")
+        @Description("Returns all the friends of a character")
         public List<Character> getFriendsOf(Character character) {
             if (character.getName().equals("Han Solo")) {
                 return Collections.singletonList(new Character("Chewbacca"));
@@ -52,6 +53,8 @@ public class QueryTest {
     public void testQueryAnnotationOnCharacterMethod() throws Exception {
         Query query = Character.class.getDeclaredMethod("getFriendsOf", Character.class).getAnnotation(Query.class);
         assertEquals(query.value(), "friendsOf");
-        assertEquals(query.description(), "Returns all the friends of a character");
+        Description description = Character.class.getDeclaredMethod("getFriendsOf", Character.class)
+                                                 .getAnnotation(Description.class);
+        assertEquals(description.value(), "Returns all the friends of a character");
     }
 }

--- a/api/src/test/java/org/eclipse/microprofile/graphql/TypeTest.java
+++ b/api/src/test/java/org/eclipse/microprofile/graphql/TypeTest.java
@@ -26,7 +26,8 @@ import static org.testng.Assert.assertEquals;
  */
 public class TypeTest {
 
-    @Type(value = "Starship", description = "A starship in StarWars")
+    @Type("Starship")
+    @Description("A starship in StarWars")
     @FieldsOrder({"name", "id", "length"})
     private static class Starship {
         private String id;
@@ -38,7 +39,8 @@ public class TypeTest {
     public void testTypeAnnotationOnStarshipClass() throws Exception {
         Type type = Starship.class.getAnnotation(Type.class);
         assertEquals(type.value(), "Starship");
-        assertEquals(type.description(), "A starship in StarWars");
+        Description description = Starship.class.getAnnotation(Description.class);
+        assertEquals(description.value(), "A starship in StarWars");
 
        FieldsOrder fieldsOrder = Starship.class.getAnnotation(FieldsOrder.class);
         assertEquals(fieldsOrder.value(), new String[] {"name", "id", "length"});

--- a/spec/src/main/asciidoc/components.asciidoc
+++ b/spec/src/main/asciidoc/components.asciidoc
@@ -75,7 +75,7 @@ public final static String CAPE =
         "   \"supernatural\": false" +
         "}";
 
-@Mutation(description="Gives a hero new equipment")
+@Mutation
 public SuperHero provisionHero(@Argument("hero") String heroName,
                                @DefaultValue(CAPE) @Argument("item") Item item) 
                                throws UnknownHeroException {

--- a/spec/src/main/asciidoc/entities.asciidoc
+++ b/spec/src/main/asciidoc/entities.asciidoc
@@ -70,8 +70,7 @@ Normally these annotations are unnecessary if the type can be serialized and/or 
 is specified in a query or mutation method. These annotations can be used to specify the name of the type in the GraphQL
 schema; by default, the entity name in the schema will be the same as the simple class name of the entity type for
 output types; for input types, the simple class name is used with "Input" appended. Thus, an entity class named 
-`com.mypkg.Tree` would create a GraphQL schema type called "Tree" and an input type called "TreeInput". These
-annotations can also be used to add a description to the entity in the schema.
+`com.mypkg.Tree` would create a GraphQL schema type called "Tree" and an input type called "TreeInput".
 
 === Java interfaces as GraphQL entity types
 
@@ -125,6 +124,11 @@ part of the `SuperHero` Java class, but _is_ part of the GraphQL entity.  This a
 `@Source` annotation. Also note that the `currentLocation` method will only be invoked if the client requests the
 `currentLocation` field in the query. This is a useful way to prevent looking up data on the server that the client is
 not interested in.
+
+=== Description
+
+The `@Description` annotation can be used to provide comments in the generated schema for entity types (both input and
+output types) and fields.
 
 === Deprecation
 

--- a/spec/src/main/asciidoc/jsonb.asciidoc
+++ b/spec/src/main/asciidoc/jsonb.asciidoc
@@ -144,5 +144,7 @@ A query that requests a Widget's construction date would get a result like this:
 }
 ----
 
-Note that this information is not automatically added to the schema, so it is considered a best practice to document
-formatting intricacies in the field's description comment.
+The date format string specified in the `@JsonbDateFormat` annotation will be used as the field's description in the
+schema, if no `@Description` annotation is provided for that field. If the same field (or property) contains both 
+`@JsonbDateFormat` and `@Description` annotations, it should be considered a best practice to document the date format
+in the description text so that the format is communicated to clients in the schema.

--- a/spec/src/main/asciidoc/mutations.asciidoc
+++ b/spec/src/main/asciidoc/mutations.asciidoc
@@ -36,7 +36,6 @@ package org.eclipse.microprofile.graphql;
 @Documented
 public @interface Mutation {
     String value() default "";
-    String description() default "";
 }
 ----
 
@@ -44,7 +43,6 @@ public @interface Mutation {
 [cols="1,1"]
 |===
 |*value*|Overrides the mutation name in the resulting schema, default will be the method name
-|*description*|Sets a description for the mutation, default will be null (no description)
 |===
 
 Mutations generally require arguments (parameters) in order to determine which entity to modify/delete or the data

--- a/spec/src/main/asciidoc/queries.asciidoc
+++ b/spec/src/main/asciidoc/queries.asciidoc
@@ -36,7 +36,6 @@ package org.eclipse.microprofile.graphql;
 @Documented
 public @interface Query {
     String value() default "";
-    String description() default "";
 }
 ----
 
@@ -44,7 +43,6 @@ public @interface Query {
 [cols="1,1"]
 |===
 |*value*|Overrides the field name in the resulting schema, default will be the method name
-|*description*|Sets a description on the field, default will be null
 |===
 
 ==== Basic POJO Example
@@ -64,6 +62,59 @@ In the previous example, an explicitly defined query named "superHero" returns a
 entity class are also implicitly defined as queries. It is possible to define fields as queries explicitly by using the
 `@Source` annotation on a parameter to the query method. More information on this is available in the
 <<entities.asciidoc#fields,Entity Fields>> section. 
+
+==== Description
+
+Queries may be documented as comments in the schema by adding a `@Description` annotation with documentation text as the
+annoation value to the query method. For example:
+
+.DescriptionExample
+[source,java,numbered]
+----
+@Query
+@Description("Returns the super hero with the specified name")
+public SuperHero superHero(@Argument("name") String name) {
+    return heroDB.getHero(name);
+}
+----
+
+This would generate a schema that would include:
+
+.DescriptionSchemaExample
+[source,numbered]
+type Query {
+  ...
+  #Returns the super hero with the specified name
+  superHero(name: String): [SuperHero] 
+  ...
+----
+
+The `@Description` annotation can also be placed on parameters of a query method to provide documentation for the
+arguments. For example:
+
+.ArgumentDescriptionExample
+[source,java,numbered]
+----
+@Query
+@Description("Returns the super hero with the specified name")
+public SuperHero superHero(@Argument("name") @Description("Super hero name, not real name") String name) {
+    return heroDB.getHero(name);
+}
+----
+
+This would generate a schema that would include:
+
+.ArgumentDescriptionSchemaExample
+[source,numbered]
+type Query {
+  ...
+  #Returns the super hero with the specified name
+  superHero(
+  #Super hero name, not real name
+  name: String
+  ): SuperHero 
+  ...
+----
 
 ==== Unnamed queries
 

--- a/tck/src/main/java/org/eclipse/microprofile/graphql/tck/SchemaAvailableTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/graphql/tck/SchemaAvailableTest.java
@@ -23,6 +23,7 @@ import java.net.HttpURLConnection;
 import java.net.URI;
 import java.net.URL;
 import java.util.logging.Logger;
+
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.shrinkwrap.api.Archive;
@@ -150,10 +151,97 @@ public class SchemaAvailableTest extends Arquillian {
         Assert.assertTrue(snippet.contains("timeOfLastBattle: DateTime"));
     }
 
+    @Test
+    @RunAsClient
+    public void testSchemaContainsDescriptionForQueryMethods() throws Exception {
+        String schema = getSchemaContent();
+        String snippet = getSchemaSnippet(schema, "type Query ");
+        Assert.assertTrue(snippet.contains("#List all super heroes in the database"));
+    }
+
+    @Test
+    @RunAsClient
+    public void testSchemaContainsDescriptionForMutationMethods() throws Exception {
+        String schema = getSchemaContent();
+        String snippet = getSchemaSnippet(schema, "type Mutation ");
+        System.out.println("snippet = " + snippet);
+        Assert.assertTrue(snippet.contains("#Removes a hero... permanently..."));
+    }
+
+    @Test
+    @RunAsClient
+    public void testSchemaContainsDescriptionForEntityTypes() throws Exception {
+        String schema = getSchemaContent();
+        Assert.assertTrue(schema.contains("#Something of use to a super hero"));
+    }
+
+    @Test
+    @RunAsClient
+    public void testSchemaContainsDescriptionForInputTypes() throws Exception {
+    }
+
+    @Test
+    @RunAsClient
+    public void testSchemaContainsDescriptionForArguments() throws Exception {
+        String schema = getSchemaContent();
+        String snippet = getSchemaSnippet(schema, "type Query ");
+        Assert.assertTrue(snippet.contains("#Super hero name, not real name"));
+    }
+
+    @Test
+    @RunAsClient
+    public void testSchemaContainsDescriptionForOutputTypeFields() throws Exception {
+        String schema = getSchemaContent();
+        String snippet = getSchemaSnippet(schema, "type SuperHero ");
+        Assert.assertTrue(snippet.contains("#Super hero name/nickname"));
+        Assert.assertTrue(snippet.contains("#Location where you are most likely to find this hero"));
+    }
+
+    @Test
+    @RunAsClient
+    public void testSchemaContainsDescriptionForInputTypeFields() throws Exception {
+        String schema = getSchemaContent();
+        String snippet = getSchemaSnippet(schema, "input SuperHeroInput ");
+        Assert.assertTrue(snippet.contains("#Super hero name/nickname"));
+        Assert.assertTrue(snippet.contains("#Powers that make this hero super"));
+    }
+
+    @Test
+    @RunAsClient
+    public void testSchemaOutputTypeFieldsContainsDescriptionFromJsonbDateFormat() throws Exception {
+        String schema = getSchemaContent();
+        String snippet = getSchemaSnippet(schema, "type SuperHero ");
+        Assert.assertTrue(snippet.contains("#MM/dd/yyyy"));
+        Assert.assertTrue(snippet.contains("#HH:mm"));
+        Assert.assertTrue(snippet.contains("#HH:mm:ss dd-MM-yyyy"));
+    }
+
+    @Test
+    @RunAsClient
+    public void testSchemaInputTypeFieldsContainsDescriptionFromJsonbDateFormat() throws Exception {
+        String schema = getSchemaContent();
+        String snippet = getSchemaSnippet(schema, "input SuperHeroInput ");
+        Assert.assertTrue(snippet.contains("#MM/dd/yyyy"));
+        Assert.assertTrue(snippet.contains("#HH:mm"));
+        Assert.assertTrue(snippet.contains("#HH:mm:ss dd-MM-yyyy"));
+    }
+
     private String getSchemaSnippet(String schema, String section) throws Exception {
         int index = schema.indexOf(section);
         Assert.assertTrue(index > -1, "Cannot find " + section + " in schema");
-        return schema.substring(index, schema.indexOf("}", index + 1));
+        char[] schemaChars = schema.toCharArray();
+        int closePos = schema.indexOf("{", index) + 1;
+        int counter = 1;
+        while (counter > 0 && closePos < schemaChars.length - 1) {
+            char c = schemaChars[++closePos];
+            if (c == '{') {
+                counter++;
+            } else if (c == '}') {
+                counter--;
+            }
+        }
+
+        return schema.substring(index, closePos);
     }
 
     private String getSchemaContent() throws Exception {

--- a/tck/src/main/java/org/eclipse/microprofile/graphql/tck/apps/superhero/api/HeroFinder.java
+++ b/tck/src/main/java/org/eclipse/microprofile/graphql/tck/apps/superhero/api/HeroFinder.java
@@ -27,6 +27,7 @@ import javax.inject.Inject;
 
 import org.eclipse.microprofile.graphql.Argument;
 import org.eclipse.microprofile.graphql.DefaultValue;
+import org.eclipse.microprofile.graphql.Description;
 import org.eclipse.microprofile.graphql.GraphQLApi;
 import org.eclipse.microprofile.graphql.GraphQLException;
 import org.eclipse.microprofile.graphql.Mutation;
@@ -52,12 +53,13 @@ public class HeroFinder {
     HeroLocator heroLocator;
 
     @Query
-    public SuperHero superHero(@Argument("name") String name) throws UnknownHeroException {
+    public SuperHero superHero(@Argument("name") @Description("Super hero name, not real name") String name) throws UnknownHeroException {
         LOG.info("superHero invoked " + name);
         return Optional.ofNullable(heroDB.getHero(name)).orElseThrow(() -> new UnknownHeroException(name));
     }
 
     @Query
+    @Description("List all super heroes in the database")
     public Collection<SuperHero> allHeroes() {
         LOG.info("allHeroes invoked");
         return heroDB.getAllHeroes();
@@ -95,7 +97,8 @@ public class HeroFinder {
         return heroDB.getHero(newHero.getName());
     }
 
-    @Mutation(description="Adds a hero to the specified team and returns the updated team.")
+    @Mutation
+    @Description("Adds a hero to the specified team and returns the updated team.")
     public Team addHeroToTeam(@Argument("hero") String heroName,
                               @Argument("team") String teamName)
                               throws UnknownTeamException {
@@ -105,7 +108,8 @@ public class HeroFinder {
                      .addMembers( heroDB.getHero(heroName) );
     }
 
-    @Mutation(description="Removes a hero to the specified team and returns the updated team.")
+    @Mutation
+    @Description("Removes a hero to the specified team and returns the updated team.")
     public Team removeHeroFromTeam(@Argument("hero") String heroName,
                                    @Argument("team") String teamName)
                                    throws UnknownTeamException {
@@ -114,7 +118,8 @@ public class HeroFinder {
                 .removeMembers( heroDB.getHero(heroName) );
     }
 
-    @Mutation(description="Removes a hero... permanently...")
+    @Mutation
+    @Description("Removes a hero... permanently...")
     public Collection<SuperHero> removeHero(@Argument("hero") String heroName) throws UnknownHeroException {
         LOG.info("removeHero invoked");
         if (heroDB.removeHero(heroName) == null) {
@@ -123,7 +128,8 @@ public class HeroFinder {
         return allHeroes();
     }
 
-    @Mutation(description="Gives a hero new equipment")
+    @Mutation
+    @Description("Gives a hero new equipment")
     public SuperHero provisionHero(@Argument("hero") String heroName,
                                    @DefaultValue(Item.CAPE) @Argument("item") Item item) 
                                    throws UnknownHeroException {
@@ -136,7 +142,8 @@ public class HeroFinder {
         return hero;
     }
 
-    @Mutation(description="Removes equipment from a hero")
+    @Mutation
+    @Description("Removes equipment from a hero")
     public SuperHero removeItemFromHero(@Argument("hero") String heroName,
                                         @Argument("itemID") long itemID) 
                                         throws UnknownHeroException {
@@ -150,7 +157,8 @@ public class HeroFinder {
         return hero;
     }
 
-    @Mutation(description="Update an item's powerLevel") 
+    @Mutation
+    @Description("Update an item's powerLevel") 
     public Item updateItemPowerLevel(@Argument("itemID") long itemID,
                                      @DefaultValue("5") @Argument("powerLevel") int newLevel) {
 

--- a/tck/src/main/java/org/eclipse/microprofile/graphql/tck/apps/superhero/model/Item.java
+++ b/tck/src/main/java/org/eclipse/microprofile/graphql/tck/apps/superhero/model/Item.java
@@ -17,9 +17,11 @@ package org.eclipse.microprofile.graphql.tck.apps.superhero.model;
 
 import java.util.Collection;
 
+import org.eclipse.microprofile.graphql.Description;
 import org.eclipse.microprofile.graphql.Id;
 import org.eclipse.microprofile.graphql.Ignore;
 
+@Description("Something of use to a super hero")
 public class Item {
 
     @Id

--- a/tck/src/main/java/org/eclipse/microprofile/graphql/tck/apps/superhero/model/SuperHero.java
+++ b/tck/src/main/java/org/eclipse/microprofile/graphql/tck/apps/superhero/model/SuperHero.java
@@ -26,12 +26,14 @@ import javax.json.bind.annotation.JsonbNumberFormat;
 import javax.json.bind.annotation.JsonbProperty;
 import javax.json.bind.annotation.JsonbTransient;
 
+import org.eclipse.microprofile.graphql.Description;
 import org.eclipse.microprofile.graphql.Query;
 
 public class SuperHero {
     private List<Team> teamAffiliations;
     private List<String> superPowers;
     private String primaryLocation;
+    @Description("Super hero name/nickname")
     private String name;
     private String realName;
     private List<Item> equipment = new ArrayList<>();
@@ -77,6 +79,7 @@ public class SuperHero {
         return superPowers;
     }
 
+    @Description("Location where you are most likely to find this hero")
     public String getPrimaryLocation() {
         return primaryLocation;
     }
@@ -93,6 +96,7 @@ public class SuperHero {
         this.teamAffiliations = teamAffiliations;
     }
 
+    @Description("Powers that make this hero super")
     public void setSuperPowers(List<String> superPowers) {
         this.superPowers = superPowers;
     }


### PR DESCRIPTION
- Adding `@Description` annotation
- Removing all `description` attributes from existing annotations
- Updating the spec docs
- Modifying the TCKs to use the new annotation, not the old attributes
- Adding new tests to verify description is added to generated schema

This should resolve issue #44 and #72.