### PR TITLE
[67] New TCK tests for `@DefaultValue` on entities

### DIFF
--- a/spec/src/main/asciidoc/components.asciidoc
+++ b/spec/src/main/asciidoc/components.asciidoc
@@ -89,6 +89,9 @@ public SuperHero provisionHero(@Argument("hero") String heroName,
     }
 ----
 
+The `@DefaultValue` annotation may also be placed on fields and setters on entity classes to specify the default for
+GraphQL fields.
+
 === Lifecycle
 
 MicroProfile GraphQL components (POJOs annotated with `@GraphQLApi`) are CDI beans. As such, their lifecycle is managed

--- a/tck/src/main/java/org/eclipse/microprofile/graphql/tck/SchemaAvailableTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/graphql/tck/SchemaAvailableTest.java
@@ -276,6 +276,22 @@ public class SchemaAvailableTest extends Arquillian {
             "Field with default value and nonnull is missing");
     }
 
+    @Test
+    @RunAsClient
+    public void testSchemaContainsDefaultValueOnEntityField() throws Exception {
+        String schema = getSchemaContent();
+        String snippet = getSchemaSnippet(schema, "input ItemInput ");
+        Assert.assertTrue(snippet.contains("supernatural: Boolean = false"));
+    }
+
+    @Test
+    @RunAsClient
+    public void testSchemaContainsDefaultValueOnEntitySetter() throws Exception {
+        String schema = getSchemaContent();
+        String snippet = getSchemaSnippet(schema, "input ItemInput ");
+        Assert.assertTrue(snippet.contains("description: String = \"An unidentified item\""));
+    }
+
     private String getSchemaContent() throws Exception {
         URL url = new URL(this.uri + PATH);
         HttpURLConnection connection = null;

--- a/tck/src/main/java/org/eclipse/microprofile/graphql/tck/apps/superhero/model/Item.java
+++ b/tck/src/main/java/org/eclipse/microprofile/graphql/tck/apps/superhero/model/Item.java
@@ -34,6 +34,7 @@ public class Item {
     private int powerLevel;
     private double height;
     private float weight;
+    @DefaultValue("false")
     private boolean supernatural;
     @Ignore
     private boolean invisible;


### PR DESCRIPTION
Adding new schema tests for `@DefaultValue` on entity fields/setters.  

This resolves issue #67.