### PR TITLE
[79+80] `@InputField` and enums

### DIFF
--- a/spec/src/main/asciidoc/entities.asciidoc
+++ b/spec/src/main/asciidoc/entities.asciidoc
@@ -125,6 +125,28 @@ part of the `SuperHero` Java class, but _is_ part of the GraphQL entity.  This a
 `currentLocation` field in the query. This is a useful way to prevent looking up data on the server that the client is
 not interested in.
 
+Users can use the `@InputField` annotation to specify a different field name for the input field in the GraphQL
+schema. For example:
+
+```
+public class Widget {
+
+    @InputField("cost")
+    private float price;
+    // ... public getters/setters
+}
+```
+
+This would result in a schema that looks something like:
+```
+type Widget {
+    price: Float!
+}
+input WidgetInput {
+    cost: Float!
+}
+```
+
 === Description
 
 The `@Description` annotation can be used to provide comments in the generated schema for entity types (both input and
@@ -174,3 +196,46 @@ One drawback to using non-nullable fields is that if there is an error loading a
 itself up causing the field to be null - and since this is itself an error condition, the implementation must return
 the non-null field error, which means that the implementation would not be able to send partial results for other child
 fields.
+
+=== Enumerable types
+
+GraphQL offers enumerable types similar to Java `enum` types. When a Java `enum` type is specified as the return type or
+parameter of a query/mutation method or a field of an entity, the implementation will produce the GraphQL `enum` type in
+the schema. For example:
+
+```
+@Type
+public class SuperHero {
+    private ShirtSize tshirtSize; // public getters/setters, ...
+
+    public enum ShirtSize {
+        S, M, L, XL
+    }
+}
+```
+
+The implementation would generate a schema that would include:
+```
+enum ShirtSize {
+  L
+  M
+  S
+  XL
+}
+
+type SuperHero @_mappedType(type : "__internal__") {
+  #...
+  tshirtSize: ShirtSize @_mappedOperation(operation : "__internal__")
+  #...
+}
+
+input SuperHeroInput @_mappedType(type : "__internal__") {
+  #...
+  tshirtSize: ShirtSize @_mappedInputField(inputField : "__internal__")
+  #...
+}
+#...
+```
+
+When using an enumerated type, it is considered a validation error when the client enters a value that is not included
+in the enumerated type.

--- a/tck/src/main/java/org/eclipse/microprofile/graphql/tck/SchemaAvailableTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/graphql/tck/SchemaAvailableTest.java
@@ -120,6 +120,37 @@ public class SchemaAvailableTest extends Arquillian {
 
     @Test
     @RunAsClient
+    public void testInputTypeOnField() throws Exception {
+        String schema = getSchemaContent();
+        String snippet = getSchemaSnippet(schema, "input SuperHeroInput ");
+        Assert.assertTrue(snippet.contains("tshirtSize: ShirtSize"),
+            "Missing expected field, \"tshirtSize\" specified in @InputField annotation");
+        Assert.assertFalse(snippet.contains("sizeOfTShirt"),
+                "Found field \"sizeOfTShirt\" that should be replaced by \"tshirtSize\" in input type");
+
+        // now verify that the Java field name is in the output type section of the schema,
+        // and that it does not include the input field name:
+        snippet = getSchemaSnippet(schema, "type SuperHero ");
+        Assert.assertFalse(snippet.contains("tshirtSize"), 
+            "Found field \"tshirtSize\" in output type, when it should only be found in the input type");
+        Assert.assertTrue(snippet.contains("sizeOfTShirt: ShirtSize"),
+                "Did not find field \"sizeOfTShirt\" in the output type");
+    }
+
+    @Test
+    @RunAsClient
+    public void testEnumAppearsInSchema() throws Exception {
+        String schema = getSchemaContent();
+        String snippet = getSchemaSnippet(schema, "enum ShirtSize ");
+        Assert.assertNotNull(snippet);
+        Assert.assertTrue(snippet.contains("S"), "Missing expected enum value, \"S\"");
+        Assert.assertTrue(snippet.contains("M"), "Missing expected enum value, \"M\"");
+        Assert.assertTrue(snippet.contains("XL"), "Missing expected enum value, \"XL\"");
+        Assert.assertTrue(snippet.contains("HULK"), "Missing expected enum value, \"HULK\"");
+    }
+
+    @Test
+    @RunAsClient
     public void testDateScalarUsedForLocalDate() throws Exception {
         String schema = getSchemaContent();
         String snippet = getSchemaSnippet(schema, "input SuperHeroInput ");

--- a/tck/src/main/java/org/eclipse/microprofile/graphql/tck/apps/superhero/model/SuperHero.java
+++ b/tck/src/main/java/org/eclipse/microprofile/graphql/tck/apps/superhero/model/SuperHero.java
@@ -27,6 +27,7 @@ import javax.json.bind.annotation.JsonbProperty;
 import javax.json.bind.annotation.JsonbTransient;
 
 import org.eclipse.microprofile.graphql.Description;
+import org.eclipse.microprofile.graphql.InputField;
 import org.eclipse.microprofile.graphql.NonNull;
 import org.eclipse.microprofile.graphql.Query;
 
@@ -56,6 +57,9 @@ public class SuperHero {
 
     @JsonbNumberFormat("0000,0000")
     private Long idNumber;
+
+    @InputField("tshirtSize")
+    private ShirtSize sizeOfTShirt;
 
     public SuperHero(){
     }
@@ -172,5 +176,22 @@ public class SuperHero {
 
     public void setTimeOfLastBattle(LocalDateTime timeOfLastBattle) {
         this.timeOfLastBattle = timeOfLastBattle;
+    }
+
+    public ShirtSize getSizeOfTShirt() {
+        return sizeOfTShirt;
+    }
+
+    public void setSizeOfTShirt(ShirtSize sizeOfTShirt) {
+        this.sizeOfTShirt = sizeOfTShirt;
+    }
+
+    public enum ShirtSize {
+        S,
+        M,
+        L,
+        XL,
+        XXL,
+        HULK
     }
 }

--- a/tck/src/main/resources/tests/createNewHero_inputFieldWithDifferentName/cleanup.graphql
+++ b/tck/src/main/resources/tests/createNewHero_inputFieldWithDifferentName/cleanup.graphql
@@ -1,0 +1,5 @@
+mutation removeHero {
+    removeHero(hero: "Captain America") {
+        name
+    }
+}

--- a/tck/src/main/resources/tests/createNewHero_inputFieldWithDifferentName/input.graphql
+++ b/tck/src/main/resources/tests/createNewHero_inputFieldWithDifferentName/input.graphql
@@ -1,0 +1,16 @@
+mutation inputFieldWithAnotherName {
+  
+   createNewHero (hero: {
+    realName: "Steven Rogers"
+    name: "Captain America"
+    dateOfLastCheckin: "09/25/2019"
+    patrolStartTime: "13:00"
+    timeOfLastBattle: "09:43:23 21-08-2019"
+    tshirtSize: XL
+  }) {
+    name
+    dateOfLastCheckin
+    patrolStartTime
+    sizeOfTShirt
+  } 
+}

--- a/tck/src/main/resources/tests/createNewHero_inputFieldWithDifferentName/output.json
+++ b/tck/src/main/resources/tests/createNewHero_inputFieldWithDifferentName/output.json
@@ -1,0 +1,10 @@
+{
+  "data": {
+    "createNewHero": {
+      "name": "Captain America",
+      "dateOfLastCheckin": "09/25/2019",
+      "patrolStartTime": "13:00",
+      "sizeOfTShirt": "XL"
+    }
+  }
+}

--- a/tck/src/main/resources/tests/createNewHero_inputFieldWithDifferentName/test.properties
+++ b/tck/src/main/resources/tests/createNewHero_inputFieldWithDifferentName/test.properties
@@ -1,0 +1,5 @@
+# This test is similar to other mutation tests, like createNewHero, but also tests that fields marked with
+# @InputField("someOtherName") can deserialize to the specified name, but still serialize to the normal field name.
+# It also tests serialization/deserialization of enum types.
+ignore=false
+priority=200

--- a/tck/src/main/resources/tests/ex_createNewHero_usingInvalidEnumValue/cleanup.graphql
+++ b/tck/src/main/resources/tests/ex_createNewHero_usingInvalidEnumValue/cleanup.graphql
@@ -1,0 +1,5 @@
+mutation removeHero {
+    removeHero(hero: "Captain America") {
+        name
+    }
+}

--- a/tck/src/main/resources/tests/ex_createNewHero_usingInvalidEnumValue/input.graphql
+++ b/tck/src/main/resources/tests/ex_createNewHero_usingInvalidEnumValue/input.graphql
@@ -1,0 +1,16 @@
+mutation inputFieldWithAnotherName {
+  
+   createNewHero (hero: {
+    realName: "Steven Rogers"
+    name: "Captain America"
+    dateOfLastCheckin: "09/25/2019"
+    patrolStartTime: "13:00"
+    timeOfLastBattle: "09:43:23 21-08-2019"
+    tshirtSize: XLTall
+  }) {
+    name
+    dateOfLastCheckin
+    patrolStartTime
+    sizeOfTShirt
+  } 
+}

--- a/tck/src/main/resources/tests/ex_createNewHero_usingInvalidEnumValue/output.json
+++ b/tck/src/main/resources/tests/ex_createNewHero_usingInvalidEnumValue/output.json
@@ -1,0 +1,23 @@
+{
+  "data": null,
+  "errors": [
+    {
+      "message": "Validation error of type WrongType: argument 'hero.tshirtSize' with value 'EnumValue{name='XLTall'}' is not a valid 'ShirtSize' @ 'createNewHero'",
+      "locations": [
+        {
+          "line": 3,
+          "column": 19,
+          "sourceName": null
+        }
+      ],
+      "description": "argument 'hero.tshirtSize' with value 'EnumValue{name='XLTall'}' is not a valid 'ShirtSize'",
+      "validationErrorType": "WrongType",
+      "queryPath": [
+        "createNewHero"
+      ],
+      "errorType": "ValidationError",
+      "path": null,
+      "extensions": null
+    }
+  ]
+}

--- a/tck/src/main/resources/tests/ex_createNewHero_usingInvalidEnumValue/test.properties
+++ b/tck/src/main/resources/tests/ex_createNewHero_usingInvalidEnumValue/test.properties
@@ -1,0 +1,4 @@
+# This test verifies that a validation error is returned when the client sends an invalid value for an enumerated type.
+# i.e. enum ShirtSize { S, M, L, XL }, but client sends a shirt size value of XL-Tall.
+ignore=false
+priority=200


### PR DESCRIPTION
Spec and TCK tests for using an alternative input field name with `@InputField` and that enums are correctly generated in the schema and handled appropriately at runtime.

Resolves issues #79 and #80.