### PR TITLE
[85] Doc void queries and query naming priority

### DIFF
--- a/spec/src/main/asciidoc/mutations.asciidoc
+++ b/spec/src/main/asciidoc/mutations.asciidoc
@@ -96,3 +96,25 @@ public SuperHero addNewPowerToHero(@Name("hero") SuperHero hero,
     return heroFromDB;
 }
 ----
+
+==== Void Mutations
+
+Like query methods, mutation methods are expected to return some value, thus it is considered a deployment error for a
+method with a `void` return type to be annotated with `@Mutation`. If a void method is annotated with the `@Mutation`
+annotation, the implementation must prevent the application from starting and should provide a log message indicating
+that this is not allowed.
+
+==== Mutation Names
+
+The name of a mutation in the schema is obtained using the following order:
+
+* if the method is annotated with a `@Mutation` annotation containing a non-empty String for it's value, that String
+value is used as the mutation name.
+* if the method is annotated with a `@Name` annotation containing a non-empty String for it's value, that String value
+is used as the mutation name.
+* if the method is annotated with a `@JsonbProperty` annotation containing a non-empty String for it's value, that
+String value is used as the mutation name.
+* if no other name can be determined, the Java method name is used as the mutation name.
+
+Note that it is considered a deployment error if more than one mutation method has the same name with the same
+arguments.

--- a/spec/src/main/asciidoc/queries.asciidoc
+++ b/spec/src/main/asciidoc/queries.asciidoc
@@ -116,5 +116,23 @@ type Query {
   ...
 ----
 
-==== Unnamed queries
+==== Void Queries
 
+By it's very nature, query methods must return some value, thus it is considered a deployment error for a method with a
+`void` return type to be annotated with `@Query`. If a void method is annotated with the `@Query` annotation, the
+implementation must prevent the application from starting and should provide a log message indicating that this is not
+allowed.
+
+==== Query Names
+
+The name of a query in the schema is obtained using the following order:
+
+* if the method is annotated with a `@Query` annotation containing a non-empty String for it's value, that String value
+is used as the query name.
+* if the method is annotated with a `@Name` annotation containing a non-empty String for it's value, that String value
+is used as the query name.
+* if the method is annotated with a `@JsonbProperty` annotation containing a non-empty String for it's value, that String
+value is used as the query name.
+* if no other name can be determined, the Java method name is used as the query name.
+
+Note that it is considered a deployment error if more than one query method has the same name with the same arguments.


### PR DESCRIPTION
This documents that void methods cannot be queries - and that the implementations should prevent apps from starting if a void method is annotated with `@Query`.

This also documents the priority for naming queries - specifically:
1) Non-empty string in `@Query` annotation
2) Non-empty string in `@Name` annotation
3) Non-empty string in `@JsonbProperty` annotation
4) The method name

and that it is considered a deployment error (prevents the app from starting) if two queries with identical arguments are used in the same app.

This resolves issue #85 and provides more details for issue #28.