### PR TITLE
[89] `@Id` should only be applied to Strings

### DIFF
--- a/api/src/main/java/org/eclipse/microprofile/graphql/Id.java
+++ b/api/src/main/java/org/eclipse/microprofile/graphql/Id.java
@@ -22,14 +22,17 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Marks a field as a Id Scalar Type.
+ * Marks a field as a ID Scalar Type.
+ * <br>
+ * Note that this annotation may only be placed on <code>String</code> fields/getters/setters/parameters. A deployment
+ * error should result if it is placed on a field/getter/setter/parameter of a different type.
  * 
  * <br><br>
  * For example, a user might annotate a method's parameter as such:
  * <pre>
  * public class Person {
  *      {@literal @}Id
- *      private int id;
+ *      private String id;
  *      private String name;
  *      private String surname;
  * 
@@ -38,7 +41,7 @@ import java.lang.annotation.Target;
  * </pre>
  */
 @Retention(RetentionPolicy.RUNTIME)
-@Target({ElementType.PARAMETER, ElementType.TYPE_USE, ElementType.FIELD, ElementType.TYPE, ElementType.METHOD})
+@Target({ElementType.PARAMETER, ElementType.FIELD, ElementType.METHOD})
 public @interface Id {
     
 }

--- a/spec/src/main/asciidoc/entities.asciidoc
+++ b/spec/src/main/asciidoc/entities.asciidoc
@@ -44,6 +44,8 @@ all GraphQL implementations are expected to handle, the following scalar types:
 - `DateTime` - which maps to a Java `java.time.LocalDateTime`.
 - `ID` - which is a specialized type serialized like a `String`. Usually, ID types are not intended to be human-readable.
 
+Note that an ID scalar must map to a Java `String` - anything else is considered a deployment error.
+
 The GraphQL specification also allows for users or implementers to define custom scalars:
 
 ==== Dates

--- a/spec/src/main/asciidoc/entities.asciidoc
+++ b/spec/src/main/asciidoc/entities.asciidoc
@@ -44,7 +44,8 @@ all GraphQL implementations are expected to handle, the following scalar types:
 - `DateTime` - which maps to a Java `java.time.LocalDateTime`.
 - `ID` - which is a specialized type serialized like a `String`. Usually, ID types are not intended to be human-readable.
 
-Note that an ID scalar must map to a Java `String` - anything else is considered a deployment error.
+Note that an ID scalar must map to a Java `String`, numerical primitive (`long`, `int`, `double`, `float`) or their
+object equivalents (`Long`, `Integer`, `Double`, `Float`), or a `java.util.UUID` - anything else is considered a deployment error.
 
 The GraphQL specification also allows for users or implementers to define custom scalars:
 

--- a/tck/src/main/java/org/eclipse/microprofile/graphql/tck/apps/basic/api/ScalarHolder.java
+++ b/tck/src/main/java/org/eclipse/microprofile/graphql/tck/apps/basic/api/ScalarHolder.java
@@ -20,6 +20,8 @@ import java.math.BigInteger;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.util.UUID;
+
 import org.eclipse.microprofile.graphql.DefaultValue;
 import org.eclipse.microprofile.graphql.Id;
 
@@ -64,6 +66,24 @@ public class ScalarHolder {
     private LocalDateTime dateTimeObject;
     @Id
     private String id;
+    @Id
+    private long longPrimitiveId;
+    @Id
+    private int intPrimitiveId;
+    @Id
+    private double doublePrimitiveId;
+    @Id
+    private float floatPrimitiveId;
+    @Id
+    private Long longObjectId;
+    @Id
+    private Integer integerObjectId;
+    @Id
+    private Double doubleObjectId;
+    @Id
+    private Float floatObjectId;
+    @Id
+    private UUID uuidId;
 
     public ScalarHolder() {
 
@@ -259,6 +279,78 @@ public class ScalarHolder {
 
     public void setId(String id) {
         this.id = id;
+    }
+
+    public long getLongPrimitiveId() {
+        return longPrimitiveId;
+    }
+
+    public void setLongPrimitiveId(long longPrimitiveId) {
+        this.longPrimitiveId = longPrimitiveId;
+    }
+
+    public int getIntPrimitiveId() {
+        return intPrimitiveId;
+    }
+
+    public void setIntPrimitiveId(int intPrimitiveId) {
+        this.intPrimitiveId = intPrimitiveId;
+    }
+
+    public double getDoublePrimitiveId() {
+        return doublePrimitiveId;
+    }
+
+    public void setDoublePrimitiveId(double doublePrimitiveId) {
+        this.doublePrimitiveId = doublePrimitiveId;
+    }
+
+    public float getFloatPrimitiveId() {
+        return floatPrimitiveId;
+    }
+
+    public void setFloatPrimitiveId(float floatPrimitiveId) {
+        this.floatPrimitiveId = floatPrimitiveId;
+    }
+
+    public Long getLongObjectId() {
+        return longObjectId;
+    }
+
+    public void setLongObjectId(Long longObjectId) {
+        this.longObjectId = longObjectId;
+    }
+
+    public Integer getIntegerObjectId() {
+        return integerObjectId;
+    }
+
+    public void setIntegerObjectId(Integer integerObjectId) {
+        this.integerObjectId = integerObjectId;
+    }
+
+    public Double getDoubleObjectId() {
+        return doubleObjectId;
+    }
+
+    public void setDoubleObjectId(Double doubleObjectId) {
+        this.doubleObjectId = doubleObjectId;
+    }
+
+    public Float getFloatObjectId() {
+        return floatObjectId;
+    }
+
+    public void setFloatObjectId(Float floatObjectId) {
+        this.floatObjectId = floatObjectId;
+    }
+
+    public UUID getUuidId() {
+        return uuidId;
+    }
+
+    public void setUuidId(UUID uuidId) {
+        this.uuidId = uuidId;
     }
 
 }

--- a/tck/src/main/resources/tests/basicScalarTests.csv
+++ b/tck/src/main/resources/tests/basicScalarTests.csv
@@ -51,3 +51,12 @@
 49|type ScalarHolder|#yyyy-MM-dd                 |Missing Default Date Format description on Output Type
 50|type ScalarHolder|#yyyy-MM-dd'T'HH:mm:ss'Z'   |Missing Default DateTime Format description on Output Type
 51|type ScalarHolder|#HH:mm:ss                   |Missing Default Time Format description on Output Type
+52| type ScalarHolder   |   longPrimitiveId: ID                                     |   Expecting a ID Scalar Type in type ScalarHolder
+53| type ScalarHolder   |   intPrimitiveId: ID                                      |   Expecting a ID Scalar Type in type ScalarHolder
+54| type ScalarHolder   |   doublePrimitiveId: ID                                   |   Expecting a ID Scalar Type in type ScalarHolder
+55| type ScalarHolder   |   floatPrimitiveId: ID                                    |   Expecting a ID Scalar Type in type ScalarHolder
+56| type ScalarHolder   |   longObjectId: ID                                        |   Expecting a ID Scalar Type in type ScalarHolder
+57| type ScalarHolder   |   integerObjectId: ID                                     |   Expecting a ID Scalar Type in type ScalarHolder
+58| type ScalarHolder   |   doubleObjectId: ID                                      |   Expecting a ID Scalar Type in type ScalarHolder
+59| type ScalarHolder   |   floatObjectId: ID                                       |   Expecting a ID Scalar Type in type ScalarHolder
+60| type ScalarHolder   |   uuidId: ID                                              |   Expecting a ID Scalar Type in type ScalarHolder


### PR DESCRIPTION
Resolves issue #89 - specifies that `@Id` should only be applied to String fields/getters/setters/parameters - anything else should be considered a deployment error.