### PR TITLE
In GraphQL, ID is a String.

### DIFF
--- a/tck/src/main/resources/tests/addItemToHero/output.json
+++ b/tck/src/main/resources/tests/addItemToHero/output.json
@@ -4,7 +4,7 @@
       "name": "Starlord",
       "equipment": [
         {
-          "id": 12345,
+          "id": "12345",
           "name": "Power Infinity Stone",
           "height": 0.001,
           "weight": 0.2,

--- a/tck/src/main/resources/tests/addItemToHeroUsingDefaultValue/output.json
+++ b/tck/src/main/resources/tests/addItemToHeroUsingDefaultValue/output.json
@@ -4,7 +4,7 @@
       "name": "Spider Man",
       "equipment": [
         {
-          "id": 1000,
+          "id": "1000",
           "name": "Cape",
           "height": 1.2,
           "weight": 0.3,

--- a/tck/src/main/resources/tests/updateItemPowerLevel/input.graphql
+++ b/tck/src/main/resources/tests/updateItemPowerLevel/input.graphql
@@ -1,6 +1,6 @@
 # Tests that the implementation can handle a default value on a primitive scalar (int) - powerLevel defaults to 5.
 mutation alterIronManSuitPower {
-  updateItemPowerLevel(itemID:1001) {
+  updateItemPowerLevel(itemID:"1001") {
     id
     name
     powerLevel

--- a/tck/src/main/resources/tests/updateItemPowerLevel/output.json
+++ b/tck/src/main/resources/tests/updateItemPowerLevel/output.json
@@ -1,7 +1,7 @@
 {
   "data": {
     "updateItemPowerLevel": {
-      "id": 1001,
+      "id": "1001",
       "name": "Iron Man Suit",
       "powerLevel": 5
     }


### PR DESCRIPTION
Even though we allow @Id to be all sorts of types, in graphQL it always needs to be a String (as per the GraphQL Spec)
So it's up to the implementation to go from String to whatever the type is in Java.
Signed-off-by:Phillip Kruger <phillip.kruger@gmail.com>