### PR TITLE
126 / 98: restrictions on arguments / return types

### DIFF
--- a/spec/src/main/asciidoc/components.asciidoc
+++ b/spec/src/main/asciidoc/components.asciidoc
@@ -41,6 +41,26 @@ For example, suppose your application was registered at host, "myhost" on TCP po
 "MyApp" (usually the context root is the name of the WAR file but without the file extension), then the schema would be
 available at: `http://myhost:50080/MyApp/graphql/schema.graphql`
 
+=== Arguments
+
+Arguments can exist for both queries and mutations and are generally represented as method parameters in Java code.
+
+For example:
+
+.Basic Argument Example
+[source,java,numbered]
+----
+@Query
+public List<SuperHero> getHeroesAt(@Name("location") String location) { //...
+----
+
+
+In this example, `location` is an argument that the client must provide when invoking the `getHeroesAt` query.
+
+Note that abstract classes, interfaces or generic types other than subtypes of `java.util.Collection` (such as
+`java.util.List` or `java.util.Set`) are not allowed to be specified as arguments. Implementations may allow additional
+types (such as `java.util.Map`), but the behavior for these types of arguments are undefined.
+
 === Default Values
 
 It is possible to specify a default value for query or mutation arguments so that the client does not need to specify a

--- a/spec/src/main/asciidoc/mutations.asciidoc
+++ b/spec/src/main/asciidoc/mutations.asciidoc
@@ -97,6 +97,10 @@ public SuperHero addNewPowerToHero(@Name("hero") SuperHero hero,
 }
 ----
 
+Note that generic types other than subtypes of `java.util.Collection` (such as `java.util.List` or `java.util.Set`) are
+not allowed to be specified as mutation return types. Implementations may allow additional types (such as
+`java.util.Map`), but the behavior for these return types are undefined.
+
 ==== Void Mutations
 
 Like query methods, mutation methods are expected to return some value, thus it is considered a deployment error for a

--- a/spec/src/main/asciidoc/queries.asciidoc
+++ b/spec/src/main/asciidoc/queries.asciidoc
@@ -56,6 +56,10 @@ public SuperHero superHero(@Name("name") String name) {
 }
 ----
 
+Note that generic types other than subtypes of `java.util.Collection` (such as `java.util.List` or `java.util.Set`) are
+not allowed to be specified as query return types. Implementations may allow additional types (such as `java.util.Map`),
+but the behavior for these return types are undefined.
+
 ==== Entity fields are also queries
 
 In the previous example, an explicitly defined query named "superHero" returns a `SuperHero` entity. The fields on that


### PR DESCRIPTION
Resolving issues #98 and #126 by documenting that arguments (input types) must not be abstract classes, interfaces or generic types (sub-types of `java.util.Collection` are allowed) and that return types from queries/mutations must not be generic types (other than sub-types of `java.util.Collection`).