### PR TITLE
[125] TCK tests for "unassociated" types/enums

### DIFF
--- a/tck/src/main/java/org/eclipse/microprofile/graphql/tck/apps/basic/api/BasicInput.java
+++ b/tck/src/main/java/org/eclipse/microprofile/graphql/tck/apps/basic/api/BasicInput.java
@@ -22,8 +22,9 @@ import org.eclipse.microprofile.graphql.Input;
  * @author Phillip Kruger (phillip.kruger@redhat.com)
  */
 @Input("BasicMessageInput")
-public class BasicInput {
+public class BasicInput implements BasicInterface {
     private String message;
+    private BasicEnum countdownPlace;
 
     public BasicInput() {
     }
@@ -38,5 +39,13 @@ public class BasicInput {
 
     public void setMessage(String message) {
         this.message = message;
+    }
+
+    public BasicEnum getCountdownPlace() {
+        return countdownPlace;
+    }
+
+    public void setCountdownPlace(BasicEnum countdownPlace) {
+        this.countdownPlace = countdownPlace;
     }
 }

--- a/tck/src/main/java/org/eclipse/microprofile/graphql/tck/apps/basic/api/BasicInterface.java
+++ b/tck/src/main/java/org/eclipse/microprofile/graphql/tck/apps/basic/api/BasicInterface.java
@@ -15,28 +15,16 @@
  */
 package org.eclipse.microprofile.graphql.tck.apps.basic.api;
 
-import org.eclipse.microprofile.graphql.Type;
+import org.eclipse.microprofile.graphql.Interface;
+import org.eclipse.microprofile.graphql.Name;
 
 /**
- * To Test the generation of a Type even if it's not used (directly) as a return type or argument.
- * @author Phillip Kruger (phillip.kruger@redhat.com)
+ * To Test the generation of a Types/Inputs/Enums even if it's not used (directly) as a return type or argument.
+ * This is the interface that is used directly.
  */
-@Type("BasicMessage")
-public class BasicType implements BasicInterface {
-    private String message;
+@Interface
+public interface BasicInterface {
+    String getMessage();
 
-    public BasicType() {
-    }
-    
-    public BasicType(String message) {
-        this.message = message;
-    }
-
-    public String getMessage() {
-        return message;
-    }
-
-    public void setMessage(String message) {
-        this.message = message;
-    }
+    void setMessage(@Name("message") String message);
 }

--- a/tck/src/main/java/org/eclipse/microprofile/graphql/tck/apps/basic/api/ScalarTestApi.java
+++ b/tck/src/main/java/org/eclipse/microprofile/graphql/tck/apps/basic/api/ScalarTestApi.java
@@ -211,5 +211,10 @@ public class ScalarTestApi {
     @Name("testId")
     public String id(){
         return getScalarHolder().getId();
-    }   
+    }  
+
+    @Query
+    public BasicInterface basicMessageEcho(@Name("input") BasicInput input) {
+        return new BasicType(input.getMessage());
+    }
 }

--- a/tck/src/main/resources/tests/basicScalarTests.csv
+++ b/tck/src/main/resources/tests/basicScalarTests.csv
@@ -61,5 +61,7 @@
 60| type ScalarHolder       |   floatObjectId: ID                                       |   Expecting a ID Scalar Type in type ScalarHolder, Float
 61| type ScalarHolder       |   uuidId: ID                                              |   Expecting a ID Scalar Type in type ScalarHolder, UUID
 62| input BasicMessageInput |   message: String                                         |   Expecting a BasicMessageInput from @Input
-63| type BasicMessage       |   message: String                                         |   Expecting a BasicMessage from @Type
-64| enum CountDown          |   THREE                                                   |   Expecting a CountDown from @Enum
+63| input BasicMessageInput |   countdownPlace: CountDown                                         |   Expecting a BasicMessageInput from @Input
+64| type BasicMessage       |   message: String                                         |   Expecting a BasicMessage from @Type
+65| enum CountDown          |   THREE                                                   |   Expecting a CountDown from @Enum
+66| interface Basic         |   message: String                                         |   Expecting a String argument called "message" in @Interface("MyInterface") BasicInterface


### PR DESCRIPTION
The "unassociated" types/enums are only put into the schema because they are associated with an interface or input type that is associated with a top level query.

Resolves issue #125. 

Signed-off-by: Andy McCright <j.andrew.mccright@gmail.com>