### PR TITLE
Typos and return Type error in the specification document

### DIFF
--- a/spec/src/main/asciidoc/errorhandling.asciidoc
+++ b/spec/src/main/asciidoc/errorhandling.asciidoc
@@ -179,4 +179,4 @@ query allHeroes {
 
 In this case, if there are any heroes that have a location blocking power, one or more errors will be returned to the
 client. However, the names of all of the heroes in the database will be returned as well as the location of all heroes
-to do not have a location blocking power.
+that do not have a location blocking power.

--- a/spec/src/main/asciidoc/intro.asciidoc
+++ b/spec/src/main/asciidoc/intro.asciidoc
@@ -95,7 +95,7 @@ Like REST, GraphQL is independent from particular transport protocols or data mo
 * it is not tied to any specific database technology or storage engine and is instead backed by existing code and data.
 
 [[what_make_graphql_different]]
-=== What make GraphQL different?
+=== What makes GraphQL different?
 In practice, here are the main differentiating features of GraphQL compared to REST:
 
 * *schema-driven*: a GraphQL API natively exposes a schema describing the structure of the data and operations (queries

--- a/spec/src/main/asciidoc/queries.asciidoc
+++ b/spec/src/main/asciidoc/queries.asciidoc
@@ -89,7 +89,7 @@ This would generate a schema that would include:
 type Query {
   ...
   #Returns the super hero with the specified name
-  superHero(name: String): [SuperHero] 
+  superHero(name: String): SuperHero 
   #...
 ----
 


### PR DESCRIPTION
I noticed that the return type in _DescriptionSchemaExample_ was `[SuperHero]` instead of `SuperHero`, and some small spelling errors

Signed-off-by: Atem Nkeng-Asong atemlefacnkengasong@gmail.com