### PR TITLE
Fix for #143 - Date format in the description

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -16,7 +16,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-image:https://github.com/eclipse/microprofile-graphql/workflows/Build/badge.svg)](https://github.com/github.com/eclipse/microprofile-graphql/actions)
+image:https://github.com/eclipse/microprofile-graphql/workflows/Build/badge.svg[link="https://github.com/github.com/eclipse/microprofile-graphql/actions"]
 image:https://badges.gitter.im/eclipse/microprofile-graphql.svg[link="https://gitter.im/eclipse/microprofile-graphql"]
 
 = Microprofile GraphQL Specification

--- a/README.asciidoc
+++ b/README.asciidoc
@@ -16,6 +16,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
+image:https://github.com/eclipse/microprofile-graphql/workflows/Build/badge.svg)](https://github.com/github.com/eclipse/microprofile-graphql/actions)
 image:https://badges.gitter.im/eclipse/microprofile-graphql.svg[link="https://gitter.im/eclipse/microprofile-graphql"]
 
 = Microprofile GraphQL Specification

--- a/spec/src/main/asciidoc/jsonb.asciidoc
+++ b/spec/src/main/asciidoc/jsonb.asciidoc
@@ -143,10 +143,43 @@ A query that requests a Widget's construction date would get a result like this:
 }
 ----
 
-The date format string specified in the `@JsonbDateFormat` annotation will be used as the field's description in the
-schema, if no `@Description` annotation is provided for that field. If the same field (or property) contains both 
-`@JsonbDateFormat` and `@Description` annotations, it should be considered a best practice to document the date format
-in the description text so that the format is communicated to clients in the schema.
+If no `@Description` annotation is provided for a date field, the date format string specified in the `@JsonbDateFormat` annotation 
+will be used as the field's description, or the default date format in the case there is not `@JsonbDateFormat` annotation. 
+
+If a `@Description` annotation is provided for a date field, the date format string specified in the `@JsonbDateFormat` annotation 
+will be appended to the given description in brackets `(...)`, or the default date format in the case there is not `@JsonbDateFormat` annotation. 
+
+Example:
+
+[source,java,numbered]
+----
+
+private LocalDate dateObject;
+
+@Description("This is another date")
+private LocalDate anotherDateObject;
+
+@JsonbDateFormat("MM dd yyyy")
+@Description("This is a formatted date")
+private LocalDate formattedDateObject;
+----
+
+will result in:
+
+[source,graphql,numbered]
+----
+type ScalarHolder {
+  #yyyy-MM-dd
+  dateObject: Date
+
+  #This is another date (yyyy-MM-dd)
+  anotherDateObject: Date
+  
+  #This is a formatted date (MM dd yyyy)
+  formattedDateObject: Date
+  #...
+}
+----
 
 === JSON-B Annotations vs MP GraphQL Annotations
 

--- a/tck/src/main/java/org/eclipse/microprofile/graphql/tck/apps/basic/api/ScalarHolder.java
+++ b/tck/src/main/java/org/eclipse/microprofile/graphql/tck/apps/basic/api/ScalarHolder.java
@@ -21,8 +21,10 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.UUID;
+import javax.json.bind.annotation.JsonbDateFormat;
 
 import org.eclipse.microprofile.graphql.DefaultValue;
+import org.eclipse.microprofile.graphql.Description;
 import org.eclipse.microprofile.graphql.Id;
 
 /**
@@ -64,6 +66,24 @@ public class ScalarHolder {
     private LocalDate dateObject;
     private LocalTime timeObject;
     private LocalDateTime dateTimeObject;
+    
+    @Description("This is another date")
+    private LocalDate anotherDateObject;
+    @Description("This is another time")
+    private LocalTime anotherTimeObject;
+    @Description("This is another datetime")
+    private LocalDateTime anotherDateTimeObject;
+    
+    @JsonbDateFormat("MM dd yyyy")
+    @Description("This is a formatted date")
+    private LocalDate formattedDateObject;
+    @JsonbDateFormat("hh:mm a")
+    @Description("This is a formatted time")
+    private LocalTime formattedTimeObject;
+    @JsonbDateFormat("MM dd yyyy 'at' hh:mm a")
+    @Description("This is a formatted datetime")
+    private LocalDateTime formattedDateTimeObject;
+    
     @Id
     private String id;
     @Id
@@ -265,6 +285,54 @@ public class ScalarHolder {
         this.dateTimeObject = dateTimeObject;
     }
 
+    public LocalDate getAnotherDateObject() {
+        return anotherDateObject;
+    }
+
+    public void setAnotherDateObject(LocalDate dateObject) {
+        this.anotherDateObject = dateObject;
+    }
+
+    public LocalTime getAnotherTimeObject() {
+        return anotherTimeObject;
+    }
+
+    public void setAnotherTimeObject(LocalTime timeObject) {
+        this.anotherTimeObject = timeObject;
+    }
+
+    public LocalDateTime getAnotherDateTimeObject() {
+        return anotherDateTimeObject;
+    }
+
+    public void setAnotherDateTimeObject(LocalDateTime dateTimeObject) {
+        this.anotherDateTimeObject = dateTimeObject;
+    }
+    
+    public LocalDate getFormattedDateObject() {
+        return formattedDateObject;
+    }
+
+    public void setFormattedDateObject(LocalDate dateObject) {
+        this.formattedDateObject = dateObject;
+    }
+
+    public LocalTime getFormattedTimeObject() {
+        return formattedTimeObject;
+    }
+
+    public void setFormattedTimeObject(LocalTime timeObject) {
+        this.formattedTimeObject = timeObject;
+    }
+
+    public LocalDateTime getFormattedDateTimeObject() {
+        return formattedDateTimeObject;
+    }
+
+    public void setFormattedDateTimeObject(LocalDateTime dateTimeObject) {
+        this.formattedDateTimeObject = dateTimeObject;
+    }
+    
     public String getId() {
         return id;
     }

--- a/tck/src/main/resources/tests/basicScalarTests.csv
+++ b/tck/src/main/resources/tests/basicScalarTests.csv
@@ -48,16 +48,22 @@
 47| type Query              |   testCharArray: [Char]                                   |   Expecting a non null Char Array Scalar Type in type Query
 48| type Query              |   testTimeObject: Time                                    |   Expecting a Time Scalar Type in type Query
 49| type Mutation           |   scalarHolder(arg0: ScalarHolderInput): ScalarHolder     |   Expecting a Mutation with the set removed from the name, scalarHolder.
-50| type ScalarHolder       |   #yyyy-MM-dd                                             |   Missing Default Date Format description on Output Type
-51| type ScalarHolder       |   #yyyy-MM-dd'T'HH:mm:ss'Z'                               |   Missing Default DateTime Format description on Output Type
-52| type ScalarHolder       |   #HH:mm:ss                                               |   Missing Default Time Format description on Output Type
-53| type ScalarHolder       |   longPrimitiveId: ID                                     |   Expecting a ID Scalar Type in type ScalarHolder, long
-54| type ScalarHolder       |   intPrimitiveId: ID                                      |   Expecting a ID Scalar Type in type ScalarHolder, int
-55| type ScalarHolder       |   longObjectId: ID                                        |   Expecting a ID Scalar Type in type ScalarHolder, long
-56| type ScalarHolder       |   integerObjectId: ID                                     |   Expecting a ID Scalar Type in type ScalarHolder, Integer
-57| type ScalarHolder       |   uuidId: ID                                              |   Expecting a ID Scalar Type in type ScalarHolder, UUID
-58| input BasicMessageInput |   message: String                                         |   Expecting a BasicMessageInput from @Input
-59| input BasicMessageInput |   countdownPlace: CountDown                               |   Expecting a BasicMessageInput from @Input
-60| type BasicMessage       |   message: String                                         |   Expecting a BasicMessage from @Type
-61| enum CountDown          |   THREE                                                   |   Expecting a CountDown from @Enum
-62| interface Basic         |   message: String                                         |   Expecting a String argument called "message" in @Interface("MyInterface") BasicInterface
+50| type ScalarHolder       |   #HH:mm:ss                                               |   Missing Default Time Format description on Output Type
+51| type ScalarHolder       |   #yyyy-MM-dd                                             |   Missing Default Date Format description on Output Type
+52| type ScalarHolder       |   #yyyy-MM-dd'T'HH:mm:ss'Z'                               |   Missing Default DateTime Format description on Output Type
+53| type ScalarHolder       |   #This is another time (HH:mm:ss)                        |   Missing Default Time Format description (appended) on Output Type
+54| type ScalarHolder       |   #This is another date (yyyy-MM-dd)                      |   Missing Default Date Format description (appended) on Output Type
+55| type ScalarHolder       |   #This is another datetime (yyyy-MM-dd'T'HH:mm:ss'Z')    |   Missing Default DateTime Format description (appended) on Output Type
+56| type ScalarHolder       |   #This is a formatted time (hh:mm a)                     |   Missing Formatted Time Format description (appended) on Output Type
+57| type ScalarHolder       |   #This is a formatted date (MM dd yyyy)                  |   Missing Formatted Date Format description (appended) on Output Type
+58| type ScalarHolder       |   #This is a formatted datetime (MM dd yyyy 'at' hh:mm a) |   Missing Formatted DateTime Format description (appended) on Output Type
+59| type ScalarHolder       |   longPrimitiveId: ID                                     |   Expecting a ID Scalar Type in type ScalarHolder, long
+60| type ScalarHolder       |   intPrimitiveId: ID                                      |   Expecting a ID Scalar Type in type ScalarHolder, int
+61| type ScalarHolder       |   longObjectId: ID                                        |   Expecting a ID Scalar Type in type ScalarHolder, long
+62| type ScalarHolder       |   integerObjectId: ID                                     |   Expecting a ID Scalar Type in type ScalarHolder, Integer
+63| type ScalarHolder       |   uuidId: ID                                              |   Expecting a ID Scalar Type in type ScalarHolder, UUID
+64| input BasicMessageInput |   message: String                                         |   Expecting a BasicMessageInput from @Input
+65| input BasicMessageInput |   countdownPlace: CountDown                               |   Expecting a BasicMessageInput from @Input
+66| type BasicMessage       |   message: String                                         |   Expecting a BasicMessage from @Type
+67| enum CountDown          |   THREE                                                   |   Expecting a CountDown from @Enum
+68| interface Basic         |   message: String                                         |   Expecting a String argument called "message" in @Interface("MyInterface") BasicInterface


### PR DESCRIPTION
This fixes issue #143 to always add the date format to a date field description.
Also added a build status badge to the readme to make the build status more visible.