### PR TITLE
New formatting annotations (Fix Issue #154)

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -71,9 +71,6 @@ MicroProfile is the optimal place to host that standard as it is open, ideally s
 This specification will focus on making it easy for developers to create a GraphQL Service/Endpoint and publish it as an API. 
 Where the data comes from (NoSQL, Relational DB, another service, etc.) is not the concern of this Proposed Specification. 
 
-== Original Proposal
-See the original proposal https://github.com/eclipse/microprofile-sandbox/blob/master/proposals/graphql/proposal/src/main/asciidoc/proposal.asciidoc[here]
-
 == Contributing
 
 Do you want to contribute to this project? link:CONTRIBUTING.adoc[Find out how you can help here].

--- a/api/src/main/java/org/eclipse/microprofile/graphql/DateFormat.java
+++ b/api/src/main/java/org/eclipse/microprofile/graphql/DateFormat.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.eclipse.microprofile.graphql;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation provides way how to set custom date format to field or JavaBean property.
+ * (or collection there of)
+ * This is similar to Jsonb (jakarta.json.bind.annotation.JsonbDateFormat) except that it adds support for TYPE_USE
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE_USE, 
+        ElementType.ANNOTATION_TYPE, 
+        ElementType.FIELD,
+        ElementType.METHOD, 
+        ElementType.TYPE, 
+        ElementType.PARAMETER, 
+        ElementType.PACKAGE})
+@Documented
+public @interface DateFormat {
+    String DEFAULT_LOCALE = "##default";
+    String DEFAULT_FORMAT = "##default";
+    
+    String value() default DEFAULT_FORMAT;
+    String locale() default DEFAULT_LOCALE;
+}

--- a/api/src/main/java/org/eclipse/microprofile/graphql/DateFormat.java
+++ b/api/src/main/java/org/eclipse/microprofile/graphql/DateFormat.java
@@ -25,7 +25,7 @@ import java.lang.annotation.Target;
 /**
  * Annotation provides way how to set custom date format to field or JavaBean property.
  * (or collection there of)
- * This is similar to Jsonb (jakarta.json.bind.annotation.JsonbDateFormat) except that it adds support for TYPE_USE
+ * This is similar to Jsonb (JsonbDateFormat) except that it adds support for TYPE_USE
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE_USE, 

--- a/api/src/main/java/org/eclipse/microprofile/graphql/NumberFormat.java
+++ b/api/src/main/java/org/eclipse/microprofile/graphql/NumberFormat.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.eclipse.microprofile.graphql;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation provides way how to set custom number format to field or JavaBean property.
+ * (or collection there of)
+ * This is similar to Jsonb (jakarta.json.bind.annotation.JsonbNumberFormat) except that it adds support for TYPE_USE
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE_USE, 
+        ElementType.ANNOTATION_TYPE, 
+        ElementType.FIELD,
+        ElementType.METHOD, 
+        ElementType.TYPE, 
+        ElementType.PARAMETER, 
+        ElementType.PACKAGE})
+@Documented
+public @interface NumberFormat {
+    String DEFAULT_LOCALE = "##default";
+    String DEFAULT_FORMAT = "##default";
+    
+    String value() default "";
+    String locale() default DEFAULT_LOCALE;
+}

--- a/api/src/main/java/org/eclipse/microprofile/graphql/NumberFormat.java
+++ b/api/src/main/java/org/eclipse/microprofile/graphql/NumberFormat.java
@@ -25,7 +25,7 @@ import java.lang.annotation.Target;
 /**
  * Annotation provides way how to set custom number format to field or JavaBean property.
  * (or collection there of)
- * This is similar to Jsonb (jakarta.json.bind.annotation.JsonbNumberFormat) except that it adds support for TYPE_USE
+ * This is similar to Jsonb (JsonbNumberFormat) except that it adds support for TYPE_USE
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE_USE, 

--- a/spec/src/main/asciidoc/entities.asciidoc
+++ b/spec/src/main/asciidoc/entities.asciidoc
@@ -56,7 +56,9 @@ Implementations may define additional custom scalars beyond those listed above.
 
 ==== Numbers
 All number scalars (Int, Double, Float, Short, Long, Byte, BigInteger and BigDecimal) can be formatted
-using the `@NumberFormat` or alternativly the JSON-B annotation `@JsonbNumberFormat` (except that `@JsonbNumberFormat` is not valid on `TYPE_USE`)
+using the `@NumberFormat` or alternatively the JSON-B annotation `@JsonbNumberFormat` (except that `@JsonbNumberFormat` is not valid on `TYPE_USE`)
+
+In the case that a property has both `@NumberFormat` and `@JsonbNumberFormat`, the GraphQL annotation (`@NumberFormat`) takes priority.
 
 When formatting is added to a number type, the formatted result will be of type String.
 
@@ -97,7 +99,9 @@ By default the date related scalars (DateTime, Date, and Time) will use a ISO fo
 - `HH:mm:ss` for Time 
 
 By adding the `@DateFormat` annotation, or alternatively JSON-B annotation `@JsonbDateFormat`, a user can change the format. However, `@JsonbDateFormat` does not 
-support usage on `TYPE_USE`
+support usage on `TYPE_USE`.
+
+In the case that a property has both `@DateFormat` and `@JsonbDateFormat`, the GraphQL annotation (`@DateFormat`) takes priority.
 
 // ==== Custom user defined scalars (v1.1)
 // @TODO: Define how to create your own scalar.
@@ -457,7 +461,8 @@ Note that the `get` is removed from the name in the schema.
 Even though `@Name` is not required on an input argument for a `@Query` or `@Mutation`, it is strongly recommended
 as it is the only guaranteed portable way to ensure the argument names.
 
-If a user compiles with `-parameters` option, then the implementation should use the Java parameter names as the schema argument names. (If no `@Name` is provided)
+If no name is provided using the `@Name` annotation and the user compiled the application class with the `-parameters` option, 
+then the implementation should use the Java parameter names as the schema argument names.
 
 Example recommended argument usage (with annotation):
 
@@ -480,7 +485,8 @@ type Query {
   # ...
 ----
 
-If the `@Name` annotation is not present, and the user did not compile with the `-parameters` option, arguments will get generic names like `arg0`, `arg1` and so on.
+If the `@Name` annotation is not present, and the user did not compile with the `-parameters` option, 
+the generated schema will use generic argument names like `arg0`, `arg1` and so on.
 
 Example argument usage (with no annotation):
 

--- a/spec/src/main/asciidoc/entities.asciidoc
+++ b/spec/src/main/asciidoc/entities.asciidoc
@@ -56,7 +56,7 @@ Implementations may define additional custom scalars beyond those listed above.
 
 ==== Numbers
 All number scalars (Int, Double, Float, Short, Long, Byte, BigInteger and BigDecimal) can be formatted
-using the JSON-B annotation `@JsonbNumberFormat`.
+using the `@NumberFormat` or alternativly the JSON-B annotation `@JsonbNumberFormat` (except that `@JsonbNumberFormat` is not valid on `TYPE_USE`)
 
 When formatting is added to a number type, the formatted result will be of type String.
 
@@ -79,6 +79,16 @@ will result in a formatted amount (South African Rand) in the result:
 }
 ----
 
+List example:
+[source,java,numbered]
+----
+@Mutation
+public SuperHero trackHeroLongLat(@Name("name") String name,
+                                 @Name("coordinates") List<List<@NumberFormat("00.0000000 'longlat'") BigDecimal>> coordinates) throws UnknownHeroException {
+    // Here add the tracking
+    return superHero;
+}
+
 ==== Dates
 By default the date related scalars (DateTime, Date, and Time) will use a ISO format.
 
@@ -86,7 +96,8 @@ By default the date related scalars (DateTime, Date, and Time) will use a ISO fo
 - `yyyy-MM-dd` for Date
 - `HH:mm:ss` for Time 
 
-By adding the JSON-B annotation `@JsonbDateFormat` a user can change the format.
+By adding the `@DateFormat` annotation, or alternatively JSON-B annotation `@JsonbDateFormat`, a user can change the format. However, `@JsonbDateFormat` does not 
+support usage on `TYPE_USE`
 
 // ==== Custom user defined scalars (v1.1)
 // @TODO: Define how to create your own scalar.
@@ -446,8 +457,7 @@ Note that the `get` is removed from the name in the schema.
 Even though `@Name` is not required on an input argument for a `@Query` or `@Mutation`, it is strongly recommended
 as it is the only guaranteed portable way to ensure the argument names.
 
-If a user compiles with `-parameters` option, then the implementation should try to use the Java parameter names as the schema argument names, 
-but this is not a requirement. Some implementations may still have trouble getting the parameter names even with the `-parameters` option.
+If a user compiles with `-parameters` option, then the implementation should use the Java parameter names as the schema argument names. (If no `@Name` is provided)
 
 Example recommended argument usage (with annotation):
 
@@ -470,8 +480,7 @@ type Query {
   # ...
 ----
 
-If the `@Name` annotation is not present, and the user did not compile with the `-parameters` option, or the implementation 
-does not support the `-parameters` option, arguments will get generic names like `arg0`, `arg1` and so on.
+If the `@Name` annotation is not present, and the user did not compile with the `-parameters` option, arguments will get generic names like `arg0`, `arg1` and so on.
 
 Example argument usage (with no annotation):
 

--- a/tck/src/main/java/org/eclipse/microprofile/graphql/tck/apps/superhero/api/HeroFinder.java
+++ b/tck/src/main/java/org/eclipse/microprofile/graphql/tck/apps/superhero/api/HeroFinder.java
@@ -296,6 +296,7 @@ public class HeroFinder {
     @Mutation
     @Description("Update a hero's favourite drink size in milliliters") 
     public SuperHero favouriteDrinkSizeInML(@Name("name") String name,
+                                     @JsonbNumberFormat(value = "000.00 'kl'") // This should be ignored due to NumberFormat below
                                      @NumberFormat(value = "000.00 'ml'") 
                                      @Name("size") Float size) throws UnknownHeroException {
         LOG.log(Level.INFO, "favouriteDrinkSizeInML invoked [{0}],[{1}]", new Object[]{name, size});
@@ -383,6 +384,7 @@ public class HeroFinder {
     @Mutation
     @Description("Log the last few places the hero was seen (Long Lat)") 
     public SuperHero trackHeroLongLat(@Name("name") String name,
+                                     @JsonbNumberFormat(value = "00.0000000 'latlong'") // This should be ignored due to NumberFormat below
                                      @Name("coordinates") List<List<@NumberFormat("00.0000000 'longlat'") BigDecimal>> coordinates) 
             throws UnknownHeroException {
         LOG.log(Level.INFO, "trackHeroLongLat invoked [{0}],[{1}]", new Object[]{name, coordinates});
@@ -450,6 +452,7 @@ public class HeroFinder {
     @Mutation
     @Description("Check in a superhero") 
     public SuperHero checkInWithCorrectDateFormat(@Name("name") String name,
+                             @JsonbDateFormat("yy dd MM") // This should be ignored due to DateFormat below
                              @DateFormat("MM/dd/yyyy") @Name("date") LocalDate localDate) throws UnknownHeroException {
         LOG.log(Level.INFO, "checkInWithCorrectDateFormat invoked [{0}],[{1}]", new Object[]{name, localDate});
         SuperHero superHero = heroDB.getHero(name);
@@ -474,6 +477,7 @@ public class HeroFinder {
     @Mutation
     @Description("Set all the important dates (US format) for a certain hero") 
     public SuperHero importantDatesUS(@Name("name") String name,
+                             @JsonbDateFormat("yy dd MM") // This should be ignored due to DateFormat below
                              @Name("dates") List<@DateFormat("MM/dd/yyyy") LocalDate> localDates) throws UnknownHeroException {
         LOG.log(Level.INFO, "importantDatesUS invoked [{0}],[{1}]", new Object[]{name, localDates});
         SuperHero superHero = heroDB.getHero(name);

--- a/tck/src/main/java/org/eclipse/microprofile/graphql/tck/apps/superhero/api/HeroFinder.java
+++ b/tck/src/main/java/org/eclipse/microprofile/graphql/tck/apps/superhero/api/HeroFinder.java
@@ -36,6 +36,7 @@ import java.util.stream.Collectors;
 import javax.inject.Inject;
 import javax.json.bind.annotation.JsonbDateFormat;
 import javax.json.bind.annotation.JsonbNumberFormat;
+import org.eclipse.microprofile.graphql.DateFormat;
 
 import org.eclipse.microprofile.graphql.DefaultValue;
 import org.eclipse.microprofile.graphql.Description;
@@ -58,6 +59,7 @@ import org.eclipse.microprofile.graphql.tck.apps.superhero.model.SuperHero;
 import org.eclipse.microprofile.graphql.tck.apps.superhero.model.Team;
 import org.eclipse.microprofile.graphql.tck.apps.superhero.model.UnknownCharacterException;
 import org.eclipse.microprofile.graphql.Name;
+import org.eclipse.microprofile.graphql.NumberFormat;
 
 @GraphQLApi
 public class HeroFinder {
@@ -294,7 +296,7 @@ public class HeroFinder {
     @Mutation
     @Description("Update a hero's favourite drink size in milliliters") 
     public SuperHero favouriteDrinkSizeInML(@Name("name") String name,
-                                     @JsonbNumberFormat(value = "000.00 'ml'") 
+                                     @NumberFormat(value = "000.00 'ml'") 
                                      @Name("size") Float size) throws UnknownHeroException {
         LOG.log(Level.INFO, "favouriteDrinkSizeInML invoked [{0}],[{1}]", new Object[]{name, size});
         SuperHero superHero = heroDB.getHero(name);
@@ -381,8 +383,8 @@ public class HeroFinder {
     @Mutation
     @Description("Log the last few places the hero was seen (Long Lat)") 
     public SuperHero trackHeroLongLat(@Name("name") String name,
-                                     @JsonbNumberFormat("00.0000000 'longlat'") 
-                                     @Name("coordinates") List<List<BigDecimal>> coordinates) throws UnknownHeroException {
+                                     @Name("coordinates") List<List<@NumberFormat("00.0000000 'longlat'") BigDecimal>> coordinates) 
+            throws UnknownHeroException {
         LOG.log(Level.INFO, "trackHeroLongLat invoked [{0}],[{1}]", new Object[]{name, coordinates});
         SuperHero superHero = heroDB.getHero(name);
         if(superHero!=null){
@@ -448,11 +450,35 @@ public class HeroFinder {
     @Mutation
     @Description("Check in a superhero") 
     public SuperHero checkInWithCorrectDateFormat(@Name("name") String name,
-                             @JsonbDateFormat("MM/dd/yyyy") @Name("date") LocalDate localDate) throws UnknownHeroException {
+                             @DateFormat("MM/dd/yyyy") @Name("date") LocalDate localDate) throws UnknownHeroException {
         LOG.log(Level.INFO, "checkInWithCorrectDateFormat invoked [{0}],[{1}]", new Object[]{name, localDate});
         SuperHero superHero = heroDB.getHero(name);
         if(superHero!=null){
             superHero.setDateOfLastCheckin(localDate);
+        }
+        return superHero;
+    }
+    
+    @Mutation
+    @Description("Set all the important dates for a certain hero") 
+    public SuperHero importantDates(@Name("name") String name,
+                             @Name("dates") List<LocalDate> localDates) throws UnknownHeroException {
+        LOG.log(Level.INFO, "importantDates invoked [{0}],[{1}]", new Object[]{name, localDates});
+        SuperHero superHero = heroDB.getHero(name);
+        if(superHero!=null){
+            superHero.setImportantDates(localDates);
+        }
+        return superHero;
+    }
+    
+    @Mutation
+    @Description("Set all the important dates (US format) for a certain hero") 
+    public SuperHero importantDatesUS(@Name("name") String name,
+                             @Name("dates") List<@DateFormat("MM/dd/yyyy") LocalDate> localDates) throws UnknownHeroException {
+        LOG.log(Level.INFO, "importantDatesUS invoked [{0}],[{1}]", new Object[]{name, localDates});
+        SuperHero superHero = heroDB.getHero(name);
+        if(superHero!=null){
+            superHero.setImportantDates(localDates);
         }
         return superHero;
     }

--- a/tck/src/main/java/org/eclipse/microprofile/graphql/tck/apps/superhero/db/HeroDatabase.java
+++ b/tck/src/main/java/org/eclipse/microprofile/graphql/tck/apps/superhero/db/HeroDatabase.java
@@ -34,8 +34,8 @@ import org.eclipse.microprofile.graphql.tck.apps.superhero.model.Team;
 
 @ApplicationScoped
 public class HeroDatabase {
-    final Map<String, SuperHero> allHeroes = new HashMap<>();
-    final Map<String, Team> allTeams = new HashMap<>();
+    private final Map<String, SuperHero> allHeroes = new HashMap<>();
+    private final Map<String, Team> allTeams = new HashMap<>();
 
     private void init(@Observes @Initialized(ApplicationScoped.class) Object init) {
 

--- a/tck/src/main/java/org/eclipse/microprofile/graphql/tck/apps/superhero/db/HeroLocator.java
+++ b/tck/src/main/java/org/eclipse/microprofile/graphql/tck/apps/superhero/db/HeroLocator.java
@@ -25,7 +25,7 @@ import javax.enterprise.event.Observes;
 
 @ApplicationScoped
 public class HeroLocator {
-    final Map<String,String> heroLocations = new HashMap<>();
+    private final Map<String,String> heroLocations = new HashMap<>();
 
     protected void init(@Observes @Initialized(ApplicationScoped.class) Object init) {
         heroLocations.put("Iron Man", "Wachovia");

--- a/tck/src/main/java/org/eclipse/microprofile/graphql/tck/apps/superhero/model/SuperHero.java
+++ b/tck/src/main/java/org/eclipse/microprofile/graphql/tck/apps/superhero/model/SuperHero.java
@@ -27,6 +27,7 @@ import javax.json.bind.annotation.JsonbDateFormat;
 import javax.json.bind.annotation.JsonbNumberFormat;
 import javax.json.bind.annotation.JsonbProperty;
 import javax.json.bind.annotation.JsonbTransient;
+import org.eclipse.microprofile.graphql.DateFormat;
 
 import org.eclipse.microprofile.graphql.Description;
 import org.eclipse.microprofile.graphql.NonNull;
@@ -77,6 +78,9 @@ public class SuperHero implements Character {
     
     private ShirtSize sizeOfTShirt;
 
+    @DateFormat("dd/MM")
+    private List<LocalDate> importantDates;
+    
     public SuperHero(){
     }
     
@@ -251,6 +255,14 @@ public class SuperHero implements Character {
 
     public void setBeenThere(Set<String> beenThere) {
         this.beenThere = beenThere;
+    }
+
+    public List<LocalDate> getImportantDates() {
+        return importantDates;
+    }
+
+    public void setImportantDates(List<LocalDate> importantDates) {
+        this.importantDates = importantDates;
     }
 
     public enum ShirtSize {

--- a/tck/src/main/java/org/eclipse/microprofile/graphql/tck/dynamic/SchemaDynamicValidityTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/graphql/tck/dynamic/SchemaDynamicValidityTest.java
@@ -29,6 +29,7 @@ import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.eclipse.microprofile.graphql.tck.dynamic.schema.SchemaTestDataProvider;
@@ -83,12 +84,24 @@ public class SchemaDynamicValidityTest extends Arquillian {
             snippet = getSchemaSnippet(schema, input.getSnippetSearchTerm());
         }
         
-        // Check if this is a negative test
-        if(input.getContainsString().startsWith("!")){
-            Assert.assertFalse(snippet.contains(input.getContainsString().substring(1)), "[" + input.getHeader() + "] " + input.getErrorMessage());
-        }else{
-            Assert.assertTrue(snippet.contains(input.getContainsString()), "[" + input.getHeader() + "] " + input.getErrorMessage());    
+        Assert.assertTrue(matchAtLeastOneOfTheSnippets(input,snippet), "[" + input.getHeader() + "] " + input.getErrorMessage());    
+    }
+    
+    private boolean matchAtLeastOneOfTheSnippets(TestData input,String snippet){
+        List<String> containsAnyOfString = input.getContainsAnyOfString();
+        for(String contains:containsAnyOfString){
+            if(contains.startsWith("!")){
+                contains = contains.substring(1);
+                if(!snippet.contains(contains)){
+                    return true;
+                }
+            }else{
+                if(snippet.contains(contains)){
+                    return true;
+                }
+            }
         }
+        return false;
     }
     
     private void saveSchemaFile(){

--- a/tck/src/main/java/org/eclipse/microprofile/graphql/tck/dynamic/schema/SchemaTestDataProvider.java
+++ b/tck/src/main/java/org/eclipse/microprofile/graphql/tck/dynamic/schema/SchemaTestDataProvider.java
@@ -127,8 +127,16 @@ public class SchemaTestDataProvider {
             snippet = null;
         }
         testData.setSnippetSearchTerm(snippet);
-        testData.setContainsString(parts[2].trim());
         
+        String containsString = parts[2].trim();
+        if(containsString.contains(OR)){
+            String[] containsStrings = containsString.split(OR);
+            for(String oneOf:containsStrings){
+                testData.addContainsString(oneOf);
+            }
+        }else{
+            testData.addContainsString(containsString);
+        }
         testData.setErrorMessage("(" + count + ") - " + parts[3].trim());
 
         return testData;
@@ -146,4 +154,5 @@ public class SchemaTestDataProvider {
     private static final String DELIMITER = "\\" + PIPE;
     private static final String COMMENT = "#";
     private static final String FILE_TYPE = ".csv";
+    private static final String OR = "'OR'";
 }

--- a/tck/src/main/java/org/eclipse/microprofile/graphql/tck/dynamic/schema/TestData.java
+++ b/tck/src/main/java/org/eclipse/microprofile/graphql/tck/dynamic/schema/TestData.java
@@ -15,6 +15,9 @@
  */
 package org.eclipse.microprofile.graphql.tck.dynamic.schema;
 
+import java.util.ArrayList;
+import java.util.List;
+
 /**
  * Simple Holder for Test Data sets
  * @author Phillip Kruger (phillip.kruger@redhat.com)
@@ -24,7 +27,7 @@ public class TestData {
     private String header;
     private String name;
     private String snippetSearchTerm;
-    private String containsString;
+    private List<String> containsAnyOfString = new ArrayList<>();
     private String errorMessage;
     
     public TestData() {
@@ -62,14 +65,18 @@ public class TestData {
         this.snippetSearchTerm = snippetSearchTerm;
     }
 
-    public String getContainsString() {
-        return containsString;
+    public List<String> getContainsAnyOfString() {
+        return containsAnyOfString;
     }
 
-    public void setContainsString(String containsString) {
-        this.containsString = containsString;
+    public void setContainsAnyOfString(List<String> containsAnyOfString) {
+        this.containsAnyOfString = containsAnyOfString;
     }
 
+    public void addContainsString(String containsString) {
+        this.containsAnyOfString.add(containsString);
+    }
+    
     public String getErrorMessage() {
         return errorMessage;
     }

--- a/tck/src/main/resources/tests/basicScalarTests.csv
+++ b/tck/src/main/resources/tests/basicScalarTests.csv
@@ -47,7 +47,7 @@
 46| type Query              |   testStringObject: String                                |   Expecting a String Scalar Type in type Query
 47| type Query              |   testCharArray: [Char]                                   |   Expecting a non null Char Array Scalar Type in type Query
 48| type Query              |   testTimeObject: Time                                    |   Expecting a Time Scalar Type in type Query
-49| type Mutation           |   scalarHolder(arg0: ScalarHolderInput): ScalarHolder     |   Expecting a Mutation with the set removed from the name, scalarHolder.
+49| type Mutation           |   scalarHolder(arg0: ScalarHolderInput): ScalarHolder 'OR' scalarHolder(scalarHolder: ScalarHolderInput): ScalarHolder   |   Expecting a Mutation with the set removed from the name, scalarHolder.
 50| type ScalarHolder       |   #HH:mm:ss                                               |   Missing Default Time Format description on Output Type
 51| type ScalarHolder       |   #yyyy-MM-dd                                             |   Missing Default Date Format description on Output Type
 52| type ScalarHolder       |   #yyyy-MM-dd'T'HH:mm:ss'Z'                               |   Missing Default DateTime Format description on Output Type
@@ -66,6 +66,6 @@
 65| type ScalarHolder       |   uuidId: ID                                              |   Expecting a ID Scalar Type in type ScalarHolder, UUID
 66| input BasicMessageInput |   message: String                                         |   Expecting a BasicMessageInput from @Input
 67| input BasicMessageInput |   countdownPlace: CountDown                               |   Expecting a BasicMessageInput from @Input
-68| type BasicMessage       |   message: String                                         |   Expecting a BasicMessage from @Type
+# 68| type BasicMessage       |   message: String                                         |   Expecting a BasicMessage from @Type
 69| enum CountDown          |   THREE                                                   |   Expecting a CountDown from @Enum
-70| interface Basic         |   message: String                                         |   Expecting a String argument called "message" in @Interface("MyInterface") BasicInterface
+# 70| interface Basic         |   message: String                                         |   Expecting a String argument called "message" in @Interface("MyInterface") BasicInterface

--- a/tck/src/main/resources/tests/basicScalarTests.csv
+++ b/tck/src/main/resources/tests/basicScalarTests.csv
@@ -66,6 +66,6 @@
 65| type ScalarHolder       |   uuidId: ID                                              |   Expecting a ID Scalar Type in type ScalarHolder, UUID
 66| input BasicMessageInput |   message: String                                         |   Expecting a BasicMessageInput from @Input
 67| input BasicMessageInput |   countdownPlace: CountDown                               |   Expecting a BasicMessageInput from @Input
-# 68| type BasicMessage       |   message: String                                         |   Expecting a BasicMessage from @Type
+68| type BasicMessage       |   message: String                                         |   Expecting a BasicMessage from @Type
 69| enum CountDown          |   THREE                                                   |   Expecting a CountDown from @Enum
-# 70| interface Basic         |   message: String                                         |   Expecting a String argument called "message" in @Interface("MyInterface") BasicInterface
+70| interface Basic         |   message: String                                         |   Expecting a String argument called "message" in @Interface("MyInterface") BasicInterface

--- a/tck/src/main/resources/tests/importantDates/cleanup.graphql
+++ b/tck/src/main/resources/tests/importantDates/cleanup.graphql
@@ -1,0 +1,6 @@
+mutation importantDates {
+  importantDates(name:"Starlord", dates:[]) {
+    name
+    importantDates
+  }
+}

--- a/tck/src/main/resources/tests/importantDates/input.graphql
+++ b/tck/src/main/resources/tests/importantDates/input.graphql
@@ -1,0 +1,6 @@
+mutation importantDates {
+  importantDates(name:"Starlord", dates:["2020-01-13","2021-02-14"]) {
+    name
+    importantDates
+  }
+}

--- a/tck/src/main/resources/tests/importantDates/output.json
+++ b/tck/src/main/resources/tests/importantDates/output.json
@@ -1,0 +1,11 @@
+{
+    "data": {
+        "importantDates": {
+            "name": "Starlord",
+            "importantDates": [
+                "13/01",
+                "14/02"
+            ]
+        }
+    }
+}

--- a/tck/src/main/resources/tests/importantDates/test.properties
+++ b/tck/src/main/resources/tests/importantDates/test.properties
@@ -1,0 +1,2 @@
+ignore=false
+priority=200

--- a/tck/src/main/resources/tests/importantDatesUS/cleanup.graphql
+++ b/tck/src/main/resources/tests/importantDatesUS/cleanup.graphql
@@ -1,0 +1,6 @@
+mutation importantDates {
+  importantDates(name:"Starlord", dates:[]) {
+    name
+    importantDates
+  }
+}

--- a/tck/src/main/resources/tests/importantDatesUS/input.graphql
+++ b/tck/src/main/resources/tests/importantDatesUS/input.graphql
@@ -1,0 +1,6 @@
+mutation importantDatesUS {
+  importantDatesUS(name:"Starlord", dates:["01/14/2020","02/15/2021"]) {
+    name
+    importantDates
+  }
+}

--- a/tck/src/main/resources/tests/importantDatesUS/output.json
+++ b/tck/src/main/resources/tests/importantDatesUS/output.json
@@ -1,0 +1,11 @@
+{
+    "data": {
+        "importantDatesUS": {
+            "name": "Starlord",
+            "importantDates": [
+                "14/01",
+                "15/02"
+            ]
+        }
+    }
+}

--- a/tck/src/main/resources/tests/importantDatesUS/test.properties
+++ b/tck/src/main/resources/tests/importantDatesUS/test.properties
@@ -1,0 +1,2 @@
+ignore=false
+priority=200


### PR DESCRIPTION
- Added a way to test more that one correct schema snippet in the schema, so we can allow both arg0 and the actual parameter name as correct.
- Fixed some warnings in the log file
- Added new Annotations, as discussed, for Number and Date formatting, that can also be used inside a generic type, like `List<@NumberFormat(...)Integer>`. This fixes issue #154 