### PR TITLE
Small changes to test the default naming of queries and mutations

### DIFF
--- a/tck/src/main/java/org/eclipse/microprofile/graphql/tck/apps/basic/api/ScalarTestApi.java
+++ b/tck/src/main/java/org/eclipse/microprofile/graphql/tck/apps/basic/api/ScalarTestApi.java
@@ -265,4 +265,14 @@ public class ScalarTestApi {
     public BasicInterface basicMessageEcho(@Name("input") BasicInput input) {
         return new BasicType(input.getMessage());
     }
+    
+    @Query
+    public String getaway(){
+        return "Just testing a name that starts with get but is not a getter";
+    }
+    
+    @Mutation
+    public String settlement(){
+        return "Just testing a name that starts with set but is not a setter";
+    }
 }

--- a/tck/src/main/java/org/eclipse/microprofile/graphql/tck/apps/superhero/api/HeroFinder.java
+++ b/tck/src/main/java/org/eclipse/microprofile/graphql/tck/apps/superhero/api/HeroFinder.java
@@ -560,7 +560,7 @@ public class HeroFinder {
     }
     
     @Query
-    public String currentLocation(@Name("superHero")@Source SuperHero hero) throws GraphQLException {
+    public String getCurrentLocation(@Name("superHero")@Source SuperHero hero) throws GraphQLException {
         LOG.log(Level.INFO, "currentLocation invoked [{0}]", hero);
         final String heroName = hero.getName();
         return heroLocator.getHeroLocation(heroName)

--- a/tck/src/main/resources/tests/schemaTests.csv
+++ b/tck/src/main/resources/tests/schemaTests.csv
@@ -88,3 +88,7 @@
 45|type Query          |   currentLocation(superHero: SuperHeroInput): String      |   Expecting a currentLocation query in Query to Source annotation
 46|type SuperHero      |   secretToken(maskFirstPart: Boolean = true): String      |   Expecting a secretToken field with a boolean argument in SuperHero due to Source annotation
 47|type Query          |   !secretToken(maskFirstPart: Boolean = true): String     |   Not expecting a secretToken query in Query
+
+# testGetAndSetNotGetterAndSetter
+48|type Query          |   getaway: String                                         |   Expecting a getaway query where the get is not removed
+49|type Mutation       |   settlement: String                                      |   Expecting a settlement mutation where the set is not removed


### PR DESCRIPTION
Signed-off-by:Phillip Kruger <phillip.kruger@gmail.com>

Added 2 new tests to make sure that we differentiate between setX and setx