### PR TITLE
Fix for #197 - Additional clarification for formatting (1.0.x)

### DIFF
--- a/spec/src/main/asciidoc/entities/scalars.asciidoc
+++ b/spec/src/main/asciidoc/entities/scalars.asciidoc
@@ -104,6 +104,28 @@ public SuperHero trackHeroLongLat(@Name("name") String name,
 }
 ----
 
+The formatting annotations can also be placed on a `Query` or `Mutation` that returns a number, example:
+
+[source,java,numbered]
+----
+@Mutation
+@NumberFormat(value = "number #", locale = "en-GB")
+public Integer transformedNumber(Integer input){
+    return input;
+}
+----
+
+This will format the input and return the formatted result, example when executing with `345` as input number:
+
+[source,json,numbered]
+----
+{
+  "data": {
+    "transformedNumber": "number 345"
+  }
+}
+----
+
 ==== Dates
 By default the date related scalars (DateTime, Date, and Time) will use an ISO format.
 
@@ -118,6 +140,28 @@ By adding the `@DateFormat` annotation, or alternatively JSON-B annotation `@Jso
 support usage on `TYPE_USE`.
 
 In the case that a property has both `@DateFormat` and `@JsonbDateFormat`, the GraphQL annotation (`@DateFormat`) takes priority.
+
+The formatting annotations can also be placed on a `Query` or `Mutation` that returns a date-like object, example:
+
+[source,java,numbered]
+----
+@Query
+@DateFormat(value = "dd MMM yyyy")
+public LocalDate transformedDate(){
+    return LocalDate.parse("2016-08-16");
+}
+----
+
+This will format the input and return the formatted result:
+
+[source,json,numbered]
+----
+{
+  "data": {
+    "transformedDate": "16 Aug 2016"
+  }
+}
+----
 
 // ==== Custom user defined scalars (v1.1)
 // @TODO: Define how to create your own scalar.

--- a/tck/src/main/java/org/eclipse/microprofile/graphql/tck/apps/basic/api/ScalarTestApi.java
+++ b/tck/src/main/java/org/eclipse/microprofile/graphql/tck/apps/basic/api/ScalarTestApi.java
@@ -21,10 +21,13 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import javax.json.bind.annotation.JsonbProperty;
+import org.eclipse.microprofile.graphql.DateFormat;
+import org.eclipse.microprofile.graphql.Description;
 import org.eclipse.microprofile.graphql.GraphQLApi;
 import org.eclipse.microprofile.graphql.Id;
 import org.eclipse.microprofile.graphql.Mutation;
 import org.eclipse.microprofile.graphql.Name;
+import org.eclipse.microprofile.graphql.NumberFormat;
 import org.eclipse.microprofile.graphql.Query;
 
 /**
@@ -274,5 +277,20 @@ public class ScalarTestApi {
     @Mutation
     public String settlement(){
         return "Just testing a name that starts with set but is not a setter";
+    }
+    
+    @Query
+    @Description("Testing transformed date as a response")
+    @DateFormat(value = "dd MMM yyyy")
+    public LocalDate transformedDate(){
+        String date = "2016-08-16";
+        return LocalDate.parse(date);
+    }
+    
+    @Mutation
+    @Description("Testing transformed number as a response")
+    @NumberFormat(value = "number #", locale = "en-GB")
+    public Integer transformedNumber(Integer input){
+        return input;
     }
 }

--- a/tck/src/main/java/org/eclipse/microprofile/graphql/tck/dynamic/schema/SchemaTestDataProvider.java
+++ b/tck/src/main/java/org/eclipse/microprofile/graphql/tck/dynamic/schema/SchemaTestDataProvider.java
@@ -132,7 +132,7 @@ public class SchemaTestDataProvider {
         if(containsString.contains(OR)){
             String[] containsStrings = containsString.split(OR);
             for(String oneOf:containsStrings){
-                testData.addContainsString(oneOf);
+                testData.addContainsString(oneOf.trim());
             }
         }else{
             testData.addContainsString(containsString);

--- a/tck/src/main/resources/tests/basicScalarDateTransformation/input.graphql
+++ b/tck/src/main/resources/tests/basicScalarDateTransformation/input.graphql
@@ -1,0 +1,3 @@
+query testTransformedDate{
+  	transformedDate
+}

--- a/tck/src/main/resources/tests/basicScalarDateTransformation/output.json
+++ b/tck/src/main/resources/tests/basicScalarDateTransformation/output.json
@@ -1,0 +1,5 @@
+{
+  "data": {
+    "transformedDate": "16 Aug 2016"
+  }
+}

--- a/tck/src/main/resources/tests/basicScalarNumberTransformation/input.graphql
+++ b/tck/src/main/resources/tests/basicScalarNumberTransformation/input.graphql
@@ -1,0 +1,3 @@
+mutation testTransformedNumber{
+    transformedNumber(input:345)
+}

--- a/tck/src/main/resources/tests/basicScalarNumberTransformation/output.json
+++ b/tck/src/main/resources/tests/basicScalarNumberTransformation/output.json
@@ -1,0 +1,5 @@
+{
+  "data": {
+    "transformedNumber": "number 345"
+  }
+}


### PR DESCRIPTION
Added spec text and TCK for case where the Query or Mutation return type is a scalar that is formatted.