### PR TITLE
Add testcase for wrongly formatted date in input-object

### DIFF
--- a/server/tck/src/main/resources/tests/wrongDateFormatInInputObject/cleanup.graphql
+++ b/server/tck/src/main/resources/tests/wrongDateFormatInInputObject/cleanup.graphql
@@ -1,0 +1,5 @@
+mutation removeHero {
+    removeHero(hero: "Black Panther") {
+        name
+    }
+}

--- a/server/tck/src/main/resources/tests/wrongDateFormatInInputObject/input.graphql
+++ b/server/tck/src/main/resources/tests/wrongDateFormatInInputObject/input.graphql
@@ -1,0 +1,18 @@
+mutation createNewHero {
+    createNewHero(hero:{
+            name: "Black Panther"
+            realName: "T'Challa"
+            superPowers: ["Top intellect"]
+            primaryLocation: "Wakanda, Africa"
+            teamAffiliations: [{name: "Avengers"}]
+            idNumber: "ID-98701234",
+            dateOfBirth: "An unparseable date"
+        }) {
+            name
+            primaryLocation
+            superPowers
+            realName
+            idNumber
+            birthday
+        }
+}

--- a/server/tck/src/main/resources/tests/wrongDateFormatInInputObject/output.json
+++ b/server/tck/src/main/resources/tests/wrongDateFormatInInputObject/output.json
@@ -1,0 +1,24 @@
+{
+    "errors": [
+        {
+            "message": "Validation error of type WrongType: argument 'dateOfBirth' with value 'StringValue{value='An unparseable date'}' is not a valid 'Date' @ 'createNewHero'",
+            "locations": [
+                {
+                    "line": 2,
+                    "column": 5
+                }
+            ],
+            "extensions": {
+                "description": "argument 'dateOfBirth' with value 'StringValue{value='An unparseable date'}' is not a valid 'Date'",
+                "validationErrorType": "WrongType",
+                "queryPath": [
+                    "createNewHero"
+                ],
+                "classification": "ValidationError"
+            }
+        }
+    ],
+    "data": {
+        "createNewHero": null
+    }
+}

--- a/server/tck/src/main/resources/tests/wrongDateFormatInInputObject/test.properties
+++ b/server/tck/src/main/resources/tests/wrongDateFormatInInputObject/test.properties
@@ -1,0 +1,2 @@
+ignore=false
+priority=200


### PR DESCRIPTION
This PR adds a test case for wrongly formatted dates in input-objects. The example ist taken from the spec (Error Handling->Structure), but aligned to the existing tests.