### PR TITLE
Add tests for `@Source` used with other inputs

### DIFF
--- a/server/tck/src/main/java/org/eclipse/microprofile/graphql/tck/apps/basic/api/SourceTestApi.java
+++ b/server/tck/src/main/java/org/eclipse/microprofile/graphql/tck/apps/basic/api/SourceTestApi.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.eclipse.microprofile.graphql.tck.apps.basic.api;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+
+import org.eclipse.microprofile.graphql.DateFormat;
+import org.eclipse.microprofile.graphql.DefaultValue;
+import org.eclipse.microprofile.graphql.GraphQLApi;
+import org.eclipse.microprofile.graphql.Query;
+import org.eclipse.microprofile.graphql.Source;
+
+/**
+ * {@code @Source} testing.
+ */
+@GraphQLApi
+public class SourceTestApi {
+
+    @Query
+    public SourceType getSource() {
+        return new SourceType();
+    }
+
+    public String stringInput(@Source SourceType source, String input) {
+        return "Input was: " + input;
+    }
+
+    public String defaultStringInput(@Source SourceType source, @DefaultValue("Default value") String input) {
+        return "Input was: " + input;
+    }
+
+    public String dateInput(@Source SourceType source, @DateFormat(value = "yyyy-MM-dd") LocalDate input) {
+        return "Input was: " + (input != null ? input.format(DateTimeFormatter.ISO_DATE) : null);
+    }
+
+}

--- a/server/tck/src/main/java/org/eclipse/microprofile/graphql/tck/apps/basic/api/SourceTestApi.java
+++ b/server/tck/src/main/java/org/eclipse/microprofile/graphql/tck/apps/basic/api/SourceTestApi.java
@@ -21,6 +21,7 @@ import java.time.format.DateTimeFormatter;
 import org.eclipse.microprofile.graphql.DateFormat;
 import org.eclipse.microprofile.graphql.DefaultValue;
 import org.eclipse.microprofile.graphql.GraphQLApi;
+import org.eclipse.microprofile.graphql.Name;
 import org.eclipse.microprofile.graphql.NonNull;
 import org.eclipse.microprofile.graphql.Query;
 import org.eclipse.microprofile.graphql.Source;
@@ -41,6 +42,10 @@ public class SourceTestApi {
     }
 
     public String nonNullStringInput(@Source SourceType source, @NonNull String input) {
+        return "Input was: " + input;
+    }
+
+    public String namedStringInput(@Source SourceType source, @Name("in") String input) {
         return "Input was: " + input;
     }
 

--- a/server/tck/src/main/java/org/eclipse/microprofile/graphql/tck/apps/basic/api/SourceTestApi.java
+++ b/server/tck/src/main/java/org/eclipse/microprofile/graphql/tck/apps/basic/api/SourceTestApi.java
@@ -21,6 +21,7 @@ import java.time.format.DateTimeFormatter;
 import org.eclipse.microprofile.graphql.DateFormat;
 import org.eclipse.microprofile.graphql.DefaultValue;
 import org.eclipse.microprofile.graphql.GraphQLApi;
+import org.eclipse.microprofile.graphql.NonNull;
 import org.eclipse.microprofile.graphql.Query;
 import org.eclipse.microprofile.graphql.Source;
 
@@ -36,6 +37,10 @@ public class SourceTestApi {
     }
 
     public String stringInput(@Source SourceType source, String input) {
+        return "Input was: " + input;
+    }
+
+    public String nonNullStringInput(@Source SourceType source, @NonNull String input) {
         return "Input was: " + input;
     }
 

--- a/server/tck/src/main/java/org/eclipse/microprofile/graphql/tck/apps/basic/api/SourceType.java
+++ b/server/tck/src/main/java/org/eclipse/microprofile/graphql/tck/apps/basic/api/SourceType.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.eclipse.microprofile.graphql.tck.apps.basic.api;
+
+/**
+ * Just used as {@code @Source}-object.
+ */
+public class SourceType {
+}

--- a/server/tck/src/main/resources/tests/sourceSchemaTests.csv
+++ b/server/tck/src/main/resources/tests/sourceSchemaTests.csv
@@ -7,3 +7,4 @@
 "yyyy-MM-dd"
 input: Date
 ): String                                   |   Expecting field dateInput with parameter input in SourceType
+6| type SourceType         |   namedStringInput(in: String): String                             |   Expecting field defaultStringInput with parameter `in` in SourceType

--- a/server/tck/src/main/resources/tests/sourceSchemaTests.csv
+++ b/server/tck/src/main/resources/tests/sourceSchemaTests.csv
@@ -1,0 +1,9 @@
+# SourceTypes
+1| type Query              |   source: SourceType                                               |   Expecting field source in Query
+2| type SourceType         |   stringInput(input: String): String                               |   Expecting field stringInput with parameter input in SourceType
+3| type SourceType         |   nonNullStringInput(input: String!): String                       |   Expecting field nonNullStringInput with non-null parameter input in SourceType
+4| type SourceType         |   defaultStringInput(input: String = "Default value"): String      |   Expecting field defaultStringInput with parameter input in SourceType
+5| type SourceType         |   dateInput(
+"yyyy-MM-dd"
+input: Date
+): String                                   |   Expecting field dateInput with parameter input in SourceType

--- a/server/tck/src/main/resources/tests/sourceWithDateInput/input.graphql
+++ b/server/tck/src/main/resources/tests/sourceWithDateInput/input.graphql
@@ -1,0 +1,5 @@
+query testSourceWithDateInput {
+	source {
+		dateInput(input: "2011-12-03")
+	}
+}

--- a/server/tck/src/main/resources/tests/sourceWithDateInput/output.json
+++ b/server/tck/src/main/resources/tests/sourceWithDateInput/output.json
@@ -1,0 +1,7 @@
+{
+  "data": {
+    "source": {
+      "dateInput": "Input was: 2011-12-03"
+    }
+  }
+}

--- a/server/tck/src/main/resources/tests/sourceWithDefaultStringInput/input.graphql
+++ b/server/tck/src/main/resources/tests/sourceWithDefaultStringInput/input.graphql
@@ -1,0 +1,5 @@
+query testSourceWithDefaultStringInput {
+	source {
+		defaultStringInput
+	}
+}

--- a/server/tck/src/main/resources/tests/sourceWithDefaultStringInput/output.json
+++ b/server/tck/src/main/resources/tests/sourceWithDefaultStringInput/output.json
@@ -1,0 +1,7 @@
+{
+  "data": {
+    "source": {
+      "defaultStringInput": "Input was: Default value"
+    }
+  }
+}

--- a/server/tck/src/main/resources/tests/sourceWithNullDateInput/input.graphql
+++ b/server/tck/src/main/resources/tests/sourceWithNullDateInput/input.graphql
@@ -1,0 +1,5 @@
+query testSourceWithNullDateInput {
+	source {
+		dateInput
+	}
+}

--- a/server/tck/src/main/resources/tests/sourceWithNullDateInput/output.json
+++ b/server/tck/src/main/resources/tests/sourceWithNullDateInput/output.json
@@ -1,0 +1,7 @@
+{
+  "data": {
+    "source": {
+      "dateInput": "Input was: null"
+    }
+  }
+}

--- a/server/tck/src/main/resources/tests/sourceWithNullOnNonNullStringInput/input.graphql
+++ b/server/tck/src/main/resources/tests/sourceWithNullOnNonNullStringInput/input.graphql
@@ -1,0 +1,5 @@
+query testSourceWithNullOnNonNullStringInput {
+	source {
+		nonNullStringInput
+	}
+}

--- a/server/tck/src/main/resources/tests/sourceWithNullOnNonNullStringInput/output.json
+++ b/server/tck/src/main/resources/tests/sourceWithNullOnNonNullStringInput/output.json
@@ -2,13 +2,22 @@
   "data": null,
   "errors": [
     {
-      "message": "Validation error of type WrongType: argument 'input' with value 'NullValue{}' must not be null @ 'nonNullStringInput'",
+      "message": "Validation error of type MissingFieldArgument: Missing field argument input @ 'source/nonNullStringInput'",
       "locations": [
         {
           "line": 3,
-          "column": 9
+          "column": 3
         }
-      ]
+      ],
+      "extensions": {
+        "description": "Missing field argument input",
+        "validationErrorType": "MissingFieldArgument",
+        "queryPath": [
+          "source",
+          "nonNullStringInput"
+        ],
+        "classification": "ValidationError"
+      }
     }
   ]
 }

--- a/server/tck/src/main/resources/tests/sourceWithNullOnNonNullStringInput/output.json
+++ b/server/tck/src/main/resources/tests/sourceWithNullOnNonNullStringInput/output.json
@@ -1,0 +1,14 @@
+{
+  "data": null,
+  "errors": [
+    {
+      "message": "Validation error of type WrongType: argument 'input' with value 'NullValue{}' must not be null @ 'nonNullStringInput'",
+      "locations": [
+        {
+          "line": 3,
+          "column": 9
+        }
+      ]
+    }
+  ]
+}

--- a/server/tck/src/main/resources/tests/sourceWithNullStringInput/input.graphql
+++ b/server/tck/src/main/resources/tests/sourceWithNullStringInput/input.graphql
@@ -1,0 +1,5 @@
+query testSourceWithNullStringInput {
+	source {
+		stringInput
+	}
+}

--- a/server/tck/src/main/resources/tests/sourceWithNullStringInput/output.json
+++ b/server/tck/src/main/resources/tests/sourceWithNullStringInput/output.json
@@ -1,0 +1,7 @@
+{
+  "data": {
+    "source": {
+      "stringInput": "Input was: null"
+    }
+  }
+}

--- a/server/tck/src/main/resources/tests/sourceWithStringInput/input.graphql
+++ b/server/tck/src/main/resources/tests/sourceWithStringInput/input.graphql
@@ -1,0 +1,5 @@
+query testSourceWithStringInput {
+	source {
+		stringInput(input: "Hello World!")
+	}
+}

--- a/server/tck/src/main/resources/tests/sourceWithStringInput/output.json
+++ b/server/tck/src/main/resources/tests/sourceWithStringInput/output.json
@@ -1,0 +1,7 @@
+{
+  "data": {
+    "source": {
+      "stringInput": "Input was: Hello World!"
+    }
+  }
+}


### PR DESCRIPTION
This PR adds some test cases for input-arguments used in conjunction with `@Source`.