### PR TITLE
Add tests for creation of referenced types

### DIFF
--- a/server/tck/src/main/java/org/eclipse/microprofile/graphql/tck/apps/basic/api/ReferencedType.java
+++ b/server/tck/src/main/java/org/eclipse/microprofile/graphql/tck/apps/basic/api/ReferencedType.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.eclipse.microprofile.graphql.tck.apps.basic.api;
+
+/**
+ * Used to test creation of referenced Types.
+ * <p>
+ * Should not be used directly as input or output type.
+ */
+public class ReferencedType {
+
+    private String value;
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(final String value) {
+        this.value = value;
+    }
+}

--- a/server/tck/src/main/java/org/eclipse/microprofile/graphql/tck/apps/basic/api/ReferencedTypeTestApi.java
+++ b/server/tck/src/main/java/org/eclipse/microprofile/graphql/tck/apps/basic/api/ReferencedTypeTestApi.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.eclipse.microprofile.graphql.tck.apps.basic.api;
+
+import org.eclipse.microprofile.graphql.GraphQLApi;
+import org.eclipse.microprofile.graphql.Mutation;
+import org.eclipse.microprofile.graphql.Query;
+
+@GraphQLApi
+public class ReferencedTypeTestApi {
+
+    @Query
+    ReferencingType referencingType() {
+        ReferencedType referencedType = new ReferencedType();
+        referencedType.setValue("value");
+        ReferencingType referencingType = new ReferencingType();
+        referencingType.setReferencedType(referencedType);
+        referencingType.setNonNullReferencedType(referencedType);
+        return referencingType;
+    }
+
+    @Mutation
+    ReferencingType addReferencingType(ReferencingType referencingType) {
+        return referencingType;
+    }
+
+
+}

--- a/server/tck/src/main/java/org/eclipse/microprofile/graphql/tck/apps/basic/api/ReferencingType.java
+++ b/server/tck/src/main/java/org/eclipse/microprofile/graphql/tck/apps/basic/api/ReferencingType.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.eclipse.microprofile.graphql.tck.apps.basic.api;
+
+import org.eclipse.microprofile.graphql.NonNull;
+
+/**
+ * Used to test the creation of {@link ReferencedType}.
+ */
+public class ReferencingType {
+
+    private ReferencedType referencedType;
+
+    @NonNull
+    private ReferencedType nonNullReferencedType;
+
+
+    public ReferencedType getReferencedType() {
+        return referencedType;
+    }
+
+    public void setReferencedType(final ReferencedType referencedType) {
+        this.referencedType = referencedType;
+    }
+
+    public ReferencedType getNonNullReferencedType() {
+        return nonNullReferencedType;
+    }
+
+    public void setNonNullReferencedType(final ReferencedType nonNullReferencedType) {
+        this.nonNullReferencedType = nonNullReferencedType;
+    }
+}

--- a/server/tck/src/main/resources/tests/referencedTypeTests.csv
+++ b/server/tck/src/main/resources/tests/referencedTypeTests.csv
@@ -1,0 +1,7 @@
+# Referenced Type Tests
+1| type ReferencingType         |   referencedType: ReferencedType                  |   Expecting field referencedType in type ReferencingType
+2| type ReferencingType         |   nonNullReferencedType: ReferencedType!          |   Expecting field nonNullReferencedType in type ReferencingType
+3| type ReferencedType          |   value: String                                   |   Expecting field value in type ReferencedType
+4| input ReferencingTypeInput   |   referencedType: ReferencedTypeInput             |   Expecting field referencedType in input ReferencingTypeInput
+5| input ReferencingTypeInput   |   nonNullReferencedType: ReferencedTypeInput!     |   Expecting field nonNullReferencedType in input ReferencingTypeInput
+6| input ReferencedTypeInput    |   value: String                                   |   Expecting field value in input ReferencingTypeInput


### PR DESCRIPTION
This PR adds tests for creation of types which are used as fields but not directly as return- or parameter-types of queries and mutations.