### PR TITLE
Add ´ as an escape-character for scheme-tests, closes #328

### DIFF
--- a/server/tck/src/main/java/org/eclipse/microprofile/graphql/tck/dynamic/schema/CsvParser.java
+++ b/server/tck/src/main/java/org/eclipse/microprofile/graphql/tck/dynamic/schema/CsvParser.java
@@ -65,7 +65,9 @@ public class CsvParser {
                 escaped = !escaped;
                 if (last == ESCAPE) {
                     //double-escape
-                    stringBuilder.appendCodePoint('\'');
+                    stringBuilder.appendCodePoint(ESCAPE);
+                    last = -1;
+                    continue;
                 }
             } else if (c == HEADER && last == '\n' && !escaped) {
                 //start of header, can only happen on new line

--- a/server/tck/src/main/java/org/eclipse/microprofile/graphql/tck/dynamic/schema/CsvParser.java
+++ b/server/tck/src/main/java/org/eclipse/microprofile/graphql/tck/dynamic/schema/CsvParser.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2020 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.eclipse.microprofile.graphql.tck.dynamic.schema;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Parses the csv-files used for schema validity tests.
+ *
+ * Uses {@code |} as separator and {@code ´} as escape character.
+ *
+ * @author Yannick Bröker (ybroeker@techfak.uni-bielefeld.de)
+ */
+public class CsvParser {
+
+    private CsvParser() {
+    }
+
+    public static List<TestData> parse(Path testFile) throws IOException {
+        Reader reader = Files.newBufferedReader(testFile);
+
+        try {
+            return parse(testFile.getFileName().toString(), reader);
+        } catch (RuntimeException e) {
+            throw new RuntimeException("Failed parsing '" + testFile + "'", e);
+        }
+    }
+
+    public static List<TestData> parse(String fileName, Reader reader) throws IOException {
+        List<TestData> testData = new ArrayList<>();
+
+        String currentHeader = "";
+
+        int partIdx = 0;
+        String[] parts = new String[4];
+
+        boolean isHeader = false;
+        boolean escaped = false;
+        int last = '\n';
+
+        StringBuilder stringBuilder = new StringBuilder();
+        for (int c = reader.read(); c != -1; c = reader.read()) {
+            if (c == ESCAPE) {
+                //start/end of escaping
+                escaped = !escaped;
+                if (last == ESCAPE) {
+                    //double-escape
+                    stringBuilder.appendCodePoint('\'');
+                }
+            } else if (c == HEADER && last == '\n' && !escaped) {
+                //start of header, can only happen on new line
+                isHeader = true;
+            } else {
+                if ((c == NEWLINE) && !escaped) {
+                    String token = stringBuilder.toString();
+                    stringBuilder = new StringBuilder();
+                    //end of header or
+                    if (isHeader) {
+                        //end of header
+                        currentHeader = token;
+                        isHeader = false;
+                    } else if (partIdx == 3) {
+                        parts[partIdx] = token;
+                        testData.add(createTestData(fileName, currentHeader, parts));
+                        partIdx = 0;
+                    }
+                } else if (c == SEPARATOR && !escaped && !isHeader) {
+                    parts[partIdx] = stringBuilder.toString();
+                    stringBuilder = new StringBuilder();
+                    partIdx++;
+                } else {
+                    stringBuilder.appendCodePoint(c);
+                }
+            }
+            last = c;
+        }
+
+        if (partIdx == 3) {
+            //clean up remaining
+            parts[partIdx] = stringBuilder.toString();
+            testData.add(createTestData(fileName, currentHeader, parts));
+        }
+
+        return testData;
+    }
+
+    private static TestData createTestData(String filename, String header, String[] parts) {
+        int count = Integer.parseInt(parts[0].trim());
+        TestData testData = new TestData();
+        testData.setName(filename);
+        testData.setHeader(header.trim());
+        testData.setCount(count);
+        String snippet = parts[1].trim();
+        if (snippet.isEmpty()) {
+            snippet = null;
+        }
+        testData.setSnippetSearchTerm(snippet);
+
+        String containsString = parts[2].trim();
+        if (containsString.contains(OR)) {
+            String[] containsStrings = containsString.split(OR);
+            for (String oneOf : containsStrings) {
+                testData.addContainsString(oneOf.trim());
+            }
+        } else {
+            testData.addContainsString(containsString);
+        }
+        testData.setErrorMessage("(" + count + ") - " + parts[3].trim());
+
+        return testData;
+    }
+
+    private static final char ESCAPE = '´';
+    private static final char HEADER = '#';
+    private static final char SEPARATOR = '|';
+    private static final char NEWLINE = '\n';
+    private static final String OR = "'OR'";
+
+}

--- a/server/tck/src/main/java/org/eclipse/microprofile/graphql/tck/dynamic/schema/SchemaTestDataProvider.java
+++ b/server/tck/src/main/java/org/eclipse/microprofile/graphql/tck/dynamic/schema/SchemaTestDataProvider.java
@@ -96,63 +96,8 @@ public class SchemaTestDataProvider {
     }
 
     private static List<TestData> toTestData(Path testFile) throws IOException{
-        List<TestData> testDataList = new LinkedList<>();
-        List<String> content = Files.readAllLines(testFile);
-        String currentHeader = "";
-        for(String line:content){
-            if(validLine(line)){
-                String[] parts = line.split(DELIMITER);
-                if(parts.length==4){
-                    TestData testData = createTestData(currentHeader,testFile.getFileName().toString(),parts);
-                    testDataList.add(testData);
-                }else{
-                    LOG.log(Level.SEVERE, "Could not add test case {0} - {1}", 
-                        new Object[]{testFile.getFileName().toString(), "Does not contain 3 parts [" + parts.length +"]"});
-                }
-            }else if (isHeader(line)){
-                currentHeader = line.substring(line.indexOf(COMMENT)+1).trim();
-            }
-        }
-        return testDataList;
+        return CsvParser.parse(testFile);
     }
 
-    private static TestData createTestData(String header, String filename,String[] parts){
-        TestData testData = new TestData();
-        testData.setCount(Integer.valueOf(parts[0]));
-        testData.setHeader(header);
-        testData.setName(filename);
-        String count = parts[0].trim();
-        String snippet = parts[1].trim();
-        if(snippet == null || snippet.isEmpty()){
-            snippet = null;
-        }
-        testData.setSnippetSearchTerm(snippet);
-        
-        String containsString = parts[2].trim();
-        if(containsString.contains(OR)){
-            String[] containsStrings = containsString.split(OR);
-            for(String oneOf:containsStrings){
-                testData.addContainsString(oneOf.trim());
-            }
-        }else{
-            testData.addContainsString(containsString);
-        }
-        testData.setErrorMessage("(" + count + ") - " + parts[3].trim());
-
-        return testData;
-    }
-
-    private static boolean validLine(String line){
-        return !line.isEmpty() && line.trim().contains(PIPE) && !isHeader(line);
-    }
-
-    private static boolean isHeader(String line){
-        return line.trim().startsWith(COMMENT);
-    }
-
-    private static final String PIPE = "|";
-    private static final String DELIMITER = "\\" + PIPE;
-    private static final String COMMENT = "#";
     private static final String FILE_TYPE = ".csv";
-    private static final String OR = "'OR'";
 }

--- a/server/tck/src/main/resources/tests/sourceSchemaTests.csv
+++ b/server/tck/src/main/resources/tests/sourceSchemaTests.csv
@@ -3,8 +3,8 @@
 2| type SourceType         |   stringInput(input: String): String                               |   Expecting field stringInput with parameter input in SourceType
 3| type SourceType         |   nonNullStringInput(input: String!): String                       |   Expecting field nonNullStringInput with non-null parameter input in SourceType
 4| type SourceType         |   defaultStringInput(input: String = "Default value"): String      |   Expecting field defaultStringInput with parameter input in SourceType
-5| type SourceType         |   dateInput(
-"yyyy-MM-dd"
-input: Date
-): String                                   |   Expecting field dateInput with parameter input in SourceType
+5| type SourceType         |   ´dateInput(
+    "yyyy-MM-dd"
+    input: Date
+  ): String´                                  |   Expecting field dateInput with parameter input in SourceType
 6| type SourceType         |   namedStringInput(in: String): String                             |   Expecting field defaultStringInput with parameter `in` in SourceType

--- a/server/tck/src/test/java/org/eclipse/microprofile/graphql/tck/dynamic/schema/CsvParserTest.java
+++ b/server/tck/src/test/java/org/eclipse/microprofile/graphql/tck/dynamic/schema/CsvParserTest.java
@@ -27,6 +27,27 @@ import org.testng.annotations.Test;
 public class CsvParserTest {
 
     @Test
+    public void shouldHandleDoubleEscape() throws IOException {
+        String content = "1| union X | ´´ | Should Handle DoubleEscape\n";
+
+        final List<TestData> testDate = CsvParser.parse("shouldHandleDoubleEscape", new StringReader(content));
+
+        Assert.assertEquals(testDate.size(), 1);
+        Assert.assertEquals(testDate.get(0).getContainsAnyOfString().get(0), "´");
+
+    }
+    @Test
+    public void shouldHandleTripleEscape() throws IOException {
+        String content = "1| union X | ´Test ´´´ | Should Handle TripleEscape\n";
+
+        final List<TestData> testDate = CsvParser.parse("shouldHandleTripleEscape", new StringReader(content));
+
+        Assert.assertEquals(testDate.size(), 1);
+        Assert.assertEquals(testDate.get(0).getContainsAnyOfString().get(0), "Test ´");
+
+    }
+
+    @Test
     public void shouldHandleEscaping() throws IOException {
         String content = "1| union X | ´Y | Z´ | Should Handle Escaping\n";
 

--- a/server/tck/src/test/java/org/eclipse/microprofile/graphql/tck/dynamic/schema/CsvParserTest.java
+++ b/server/tck/src/test/java/org/eclipse/microprofile/graphql/tck/dynamic/schema/CsvParserTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2020 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.eclipse.microprofile.graphql.tck.dynamic.schema;
+
+import java.io.IOException;
+import java.io.StringReader;
+import java.util.List;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class CsvParserTest {
+
+    @Test
+    public void shouldHandleEscaping() throws IOException {
+        String content = "1| union X | ´Y | Z´ | Should Handle Escaping\n";
+
+        final List<TestData> testDate = CsvParser.parse("shouldHandleEscaping", new StringReader(content));
+
+        Assert.assertEquals(testDate.size(), 1);
+        Assert.assertEquals(testDate.get(0).getContainsAnyOfString().get(0), "Y | Z");
+        Assert.assertEquals(testDate.get(0).getErrorMessage(), "(1) - Should Handle Escaping");
+    }
+
+    @Test
+    public void shouldHandleOr() throws IOException {
+        String content = "49| type Mutation           |   "
+                + "scalarHolder(arg0: ScalarHolderInput): ScalarHolder 'OR' scalarHolder(scalarHolder: ScalarHolderInput): ScalarHolder   "
+                + "|   Expecting a Mutation with the set removed from the name, scalarHolder.\n";
+
+        final List<TestData> testDate = CsvParser.parse("shouldHandleEscaping", new StringReader(content));
+
+        Assert.assertEquals(testDate.size(), 1);
+        Assert.assertEquals(testDate.get(0).getContainsAnyOfString().size(), 2);
+        Assert.assertEquals(testDate.get(0).getContainsAnyOfString().get(0), "scalarHolder(arg0: ScalarHolderInput): ScalarHolder");
+        Assert.assertEquals(testDate.get(0).getContainsAnyOfString().get(1), "scalarHolder(scalarHolder: ScalarHolderInput): ScalarHolder");
+    }
+
+    @Test
+    public void shouldHandleMultilineEscaping() throws IOException {
+        String content = "5| type SourceType         |   ´dateInput(\n"
+                + "    \"yyyy-MM-dd\"\n"
+                + "    input: Date\n"
+                + "  ): String´                                  |   Expecting field dateInput with parameter input in SourceType\n";
+
+        final List<TestData> testDate = CsvParser.parse("shouldHandleEscaping", new StringReader(content));
+
+        Assert.assertEquals(testDate.size(), 1);
+        Assert.assertEquals(testDate.get(0).getContainsAnyOfString().get(0), "dateInput(\n"
+                + "    \"yyyy-MM-dd\"\n"
+                + "    input: Date\n"
+                + "  ): String");
+    }
+
+    @Test
+    public void shouldIgnoreCommentsInLine() throws IOException {
+        String content = "59| type ScalarHolder | \"#0.0 en-GB\" | Missing Number Format description on Output Type\n";
+
+        final List<TestData> testDate = CsvParser.parse("shouldIgnoreCommentsInLine", new StringReader(content));
+
+        Assert.assertEquals(testDate.size(), 1);
+        Assert.assertEquals(testDate.get(0).getContainsAnyOfString().get(0), "\"#0.0 en-GB\"");
+    }
+
+    @Test
+    public void shouldHandleComments() throws IOException {
+        String content = "# Basic Scalar Types\n"
+                + "1| type ScalarHolder | bigDecimalObject: BigDecimal | Expecting a BigDecimal Scalar Type in type ScalarHolder\n";
+
+        final List<TestData> testDate = CsvParser.parse("shouldHandleComments", new StringReader(content));
+
+        Assert.assertEquals(testDate.size(), 1);
+        Assert.assertEquals(testDate.get(0).getHeader(), "Basic Scalar Types");
+        Assert.assertEquals(testDate.get(0).getCount(), 1);
+    }
+}


### PR DESCRIPTION
This PR adds `´` as an escape character for the csv-files used for schema-validity tests.

`´` was chosen because `'` or `"` would break existing tests, since both are already used.
Content between two `´´` is used without change, eg `|` and new lines aren't used to split records. `´´` can be used if a single `´` is required.

This was tested against smallrye-graphql, which contains all tests from this project and some additional tests.

**Alternatives** 

Instead of `´` any other character that is currently unused can be used. 

Using an existing CSV parser would also be an alternative to a handwritten parser.