### PR TITLE
Formatting types

### DIFF
--- a/spec/src/main/asciidoc/entities/description.asciidoc
+++ b/spec/src/main/asciidoc/entities/description.asciidoc
@@ -48,10 +48,10 @@ type Query {
 Formatting annotations like `@NumberFormat` and `@DateFormat` ( or `@JsonbDateFormat` and `@JsonbNumberFormat` from JsonB) can be used to transform data at runtime (see <<scalars>>) 
 
 If no `@Description` annotation is provided for a date or number field, the format string specified in the relative annotation (`@NumberFormat` or `@DateFormat` or `@JsonbDateFormat` or `@JsonbNumberFormat`) 
-will be used as the field's description, or, for dates only, the default date format in the case there is no `@DateFormat` or `@JsonbDateFormat` annotation.
+will be used as the field's description, or, for dates only, the default date format, or just the text `ISO-8601`, in the case there is no `@DateFormat` or `@JsonbDateFormat` annotation.
 
 If a `@Description` annotation is provided for a date or number field, the format string specified in the relative annotation (`@NumberFormat` or `@DateFormat` or `@JsonbDateFormat` or `@JsonbNumberFormat`)
-will be appended to the given description in brackets `(...)`, or, for dates only, the default date format in the case there is no `@DateFormat` or `@JsonbDateFormat` annotation. 
+will be appended to the given description in brackets `(...)`, or, for dates only, the default date format, or just the text `ISO-8601`, in the case there is no `@DateFormat` or `@JsonbDateFormat` annotation. 
 
 Example:
 
@@ -80,10 +80,10 @@ will result in:
 [source,graphql,numbered]
 ----
 type ScalarHolder {
-  "yyyy-MM-dd"
+  "ISO-8601"
   dateObject: Date
 
-  "This is another date (yyyy-MM-dd)"
+  "This is another date (ISO-8601)"
   anotherDateObject: Date
   
   "This is a formatted date (MM dd yyyy)"

--- a/spec/src/main/asciidoc/entities/scalars.asciidoc
+++ b/spec/src/main/asciidoc/entities/scalars.asciidoc
@@ -72,7 +72,8 @@ using the `@NumberFormat` or alternatively the JSON-B annotation `@JsonbNumberFo
 
 In the case that a property has both `@NumberFormat` and `@JsonbNumberFormat`, the GraphQL annotation (`@NumberFormat`) takes priority.
 
-When formatting is added to a number type, the formatted result will be of type String.
+When formatting is added to a number type, the formatted result will be of type String. The type in the schema could be defined as String or another Custom Scalar to
+indicate the formatting.
 
 Example:
 [source,java,numbered]
@@ -127,7 +128,7 @@ This will format the input and return the formatted result, example when executi
 ----
 
 ==== Dates
-By default the date related scalars (DateTime, Date, and Time) will use an ISO format.
+By default the date related scalars (DateTime, Date, and Time) will use an ISO-8601 format.
 
 - `yyyy-MM-dd\'T\'HH:mm:ss` for DateTime
 - `yyyy-MM-dd\'T\'HH:mm:ssZ` for OffsetDateTime
@@ -140,6 +141,9 @@ By adding the `@DateFormat` annotation, or alternatively JSON-B annotation `@Jso
 support usage on `TYPE_USE`.
 
 In the case that a property has both `@DateFormat` and `@JsonbDateFormat`, the GraphQL annotation (`@DateFormat`) takes priority.
+
+When formatting is added to a date type, the formatted result will be of type String. The type in the schema could be defined as String or another Custom Scalar to
+indicate the formatting.
 
 The formatting annotations can also be placed on a `Query` or `Mutation` that returns a date-like object, example:
 

--- a/tck/src/main/java/org/eclipse/microprofile/graphql/tck/dynamic/execution/GraphQLTestDataProvider.java
+++ b/tck/src/main/java/org/eclipse/microprofile/graphql/tck/dynamic/execution/GraphQLTestDataProvider.java
@@ -59,7 +59,10 @@ public class GraphQLTestDataProvider {
 
     @DataProvider(name="specification")
     public static Object[][] getSpecificationTestData(){
-        return getTestData(DataFrom.specification);
+        if(!disableSpecificationTests()){
+            return getTestData(DataFrom.specification);
+        }
+        return toObjectArray(Collections.EMPTY_LIST);
     }
 
     @DataProvider(name="implementation")
@@ -235,5 +238,9 @@ public class GraphQLTestDataProvider {
         try (JsonReader jsonReader = Json.createReader(new StringReader(jsonString))) {
             return jsonReader.readObject();
         }
+    }
+    
+    private static boolean disableSpecificationTests(){
+        return Boolean.valueOf(System.getProperty("disableSpecificationTests", "false"));
     }
 }

--- a/tck/src/main/java/org/eclipse/microprofile/graphql/tck/dynamic/schema/SchemaTestDataProvider.java
+++ b/tck/src/main/java/org/eclipse/microprofile/graphql/tck/dynamic/schema/SchemaTestDataProvider.java
@@ -58,15 +58,21 @@ public class SchemaTestDataProvider {
 
     private static List<Path> getDataFiles() {
         List<Path> f = new ArrayList<>();
+        
+        // Implementation specific tests
         try {
             f.addAll(toListOfPaths(DynamicPaths.getDataForImplementation()));
         } catch (IOException ex) {
             LOG.log(Level.INFO, "No implementation specific tests found [{0}]", ex.getMessage());
         }
-        try {
-            f.addAll(toListOfPaths(DynamicPaths.getDataForSpecification()));
-        } catch (Exception ex) {
-            LOG.log(Level.WARNING, "No specification tests found [{0}]", ex.getMessage());
+        
+        // Specification test
+        if(!disableSpecificationTests()){
+            try {
+                f.addAll(toListOfPaths(DynamicPaths.getDataForSpecification()));
+            } catch (Exception ex) {
+                LOG.log(Level.WARNING, "No specification tests found [{0}]", ex.getMessage());
+            }
         }
 
         return f;
@@ -150,6 +156,10 @@ public class SchemaTestDataProvider {
         return line.trim().startsWith(COMMENT);
     }
 
+    private static boolean disableSpecificationTests(){
+        return Boolean.valueOf(System.getProperty("disableSpecificationTests", "false"));
+    }
+    
     private static final String PIPE = "|";
     private static final String DELIMITER = "\\" + PIPE;
     private static final String COMMENT = "#";

--- a/tck/src/main/resources/tests/basicScalarMutation/input.graphql
+++ b/tck/src/main/resources/tests/basicScalarMutation/input.graphql
@@ -19,8 +19,8 @@ mutation scalarHolderMutation {
     longObject:12
     longPrimitiveId:13
     longObjectId:14
-    formattedLongPrimitive:15
-    formattedLongObject:16
+    formattedLongPrimitive:"15"
+    formattedLongObject:"16"
     doublePrimitive:17
     doubleObject:18
   }) {

--- a/tck/src/main/resources/tests/basicScalarTests.csv
+++ b/tck/src/main/resources/tests/basicScalarTests.csv
@@ -1,71 +1,71 @@
 # Basic Scalar Types
-1|  type ScalarHolder       |   bigDecimalObject: BigDecimal                            |   Expecting a BigDecimal Scalar Type in type ScalarHolder
-2|  type ScalarHolder       |   bigIntegerObject: BigInteger                            |   Expecting a BigInteger Scalar Type in type ScalarHolder
-3|  type ScalarHolder       |   booleanObject: Boolean                                  |   Expecting a Boolean Scalar Type in type ScalarHolder
-4|  type ScalarHolder       |   booleanPrimitive: Boolean!                              |   Expecting a non null Boolean Scalar Type in type ScalarHolder
-5|  type ScalarHolder       |   byteObject: Int                                         |   Expecting a Int Scalar Type (for Byte Java Type) in type ScalarHolder
-6|  type ScalarHolder       |   bytePrimitive: Int!                                     |   Expecting a non null Int Scalar Type (for byte Java Type) in type ScalarHolder
-7|  type ScalarHolder       |   charObject: String                                      |   Expecting a String Scalar (for Java Char) Type in type ScalarHolder
-8|  type ScalarHolder       |   charPrimitive: String!                                  |   Expecting a non null String Scalar (for Java char) Type in type ScalarHolder
-9|  type ScalarHolder       |   dateObject: Date                                        |   Expecting a Date Scalar Type in type ScalarHolder
-10| type ScalarHolder       |   dateTimeObject: DateTime                                |   Expecting a DateTime Scalar Type in type ScalarHolder
-11| type ScalarHolder       |   doubleObject: Float                                     |   Expecting a Float Scalar Type in type ScalarHolder
-12| type ScalarHolder       |   doublePrimitive: Float!                                 |   Expecting a non null Float Scalar Type in type ScalarHolder
-13| type ScalarHolder       |   floatObject: Float                                      |   Expecting a Float Scalar Type in type ScalarHolder
-14| type ScalarHolder       |   floatPrimitive: Float!                                  |   Expecting a non null Float Scalar Type in type ScalarHolder
-15| type ScalarHolder       |   id: ID                                                  |   Expecting a ID Scalar Type in type ScalarHolder
-16| type ScalarHolder       |   intObject: Int                                          |   Expecting a Int Scalar Type in type ScalarHolder
-17| type ScalarHolder       |   intPrimitive: Int!                                      |   Expecting a non null Int Scalar Type in type ScalarHolder
-18| type ScalarHolder       |   longObject: BigInteger                                  |   Expecting a BigInteger Scalar (for Java Long) Type in type ScalarHolder
-19| type ScalarHolder       |   longPrimitive: BigInteger!                              |   Expecting a non null BigInteger (for Java long) Scalar Type in type ScalarHolder
-20| type ScalarHolder       |   shortObject: Int                                        |   Expecting a Int Scalar Type (for Short Java Type) in type ScalarHolder
-21| type ScalarHolder       |   shortPrimitive: Int!                                    |   Expecting a non null Int Scalar Type (for short Java Type) in type ScalarHolder
-22| type ScalarHolder       |   stringObject: String                                    |   Expecting a String Scalar Type in type ScalarHolder
-23| type ScalarHolder       |   charArray: [String]                                     |   Expecting a String Array Scalar (for Java Char[]) Type in type ScalarHolder
-24| type ScalarHolder       |   timeObject: Time                                        |   Expecting a Time Scalar Type in type ScalarHolder
-25| type Query              |   testBigDecimalObject: BigDecimal                        |   Expecting a BigDecimal Scalar Type in type Query
-26| type Query              |   testBigIntegerObject: BigInteger                        |   Expecting a BigInteger Scalar Type in type Query
-27| type Query              |   booleanObject: Boolean                                  |   Expecting a Boolean Scalar Type in type Query, with the is removed from the name
-28| type Query              |   booleanPrimitive: Boolean!                              |   Expecting a non null Boolean Scalar Type in type Query, with the is removed from the name
-29| type Query              |   testByteObject: Int                                     |   Expecting a Int Scalar Type (for Byte Java Type) in type Query
-30| type Query              |   testBytePrimitive: Int!                                 |   Expecting a non null Int Scalar Type (for byte Java Type) in type Query
-31| type Query              |   testCharObject: String                                  |   Expecting a String Scalar (for Java Char) Type in type Query
-32| type Query              |   testCharPrimitive: String!                              |   Expecting a non null String Scalar (for Java char) Type in type Query
-33| type Query              |   testDateObject: Date                                    |   Expecting a Date Scalar Type in type Query
-34| type Query              |   testDateTimeObject: DateTime                            |   Expecting a DateTime Scalar Type in type Query
-35| type Query              |   testDoubleObject: Float                                 |   Expecting a Float Scalar Type in type Query
-36| type Query              |   testDoublePrimitive: Float!                             |   Expecting a non null Float Scalar Type in type Query
-37| type Query              |   testFloatObject: Float                                  |   Expecting a Float Scalar Type in type Query
-38| type Query              |   testFloatPrimitive: Float!                              |   Expecting a non null Float Scalar Type in type Query
-39| type Query              |   testId: ID                                              |   Expecting a ID Scalar Type in type Query
-40| type Query              |   testIntObject: Int                                      |   Expecting a Int Scalar Type in type Query
-41| type Query              |   testIntPrimitive: Int!                                  |   Expecting a non null Int Scalar Type in type Query
-42| type Query              |   testLongObject: BigInteger                              |   Expecting a BigInteger Scalar (for Java Long) Type in type Query
-43| type Query              |   testLongPrimitive: BigInteger!                          |   Expecting a non null BigInteger Scalar (for Java long) Type in type Query
-44| type Query              |   shortObject: Int                                        |   Expecting a Int Scalar Type (for Short Java type) in type Query, with the get removed from the name
-45| type Query              |   shortPrimitive: Int!                                    |   Expecting a non null Int Scalar Type (for short Java type) in type Query, with the get removed from the name
-46| type Query              |   testStringObject: String                                |   Expecting a String Scalar Type in type Query
-47| type Query              |   testCharArray: [String]                                 |   Expecting a non null Stirng Array (for Java Char[]) Scalar Type in type Query
-48| type Query              |   testTimeObject: Time                                    |   Expecting a Time Scalar Type in type Query
-49| type Mutation           |   scalarHolder(arg0: ScalarHolderInput): ScalarHolder 'OR' scalarHolder(scalarHolder: ScalarHolderInput): ScalarHolder   |   Expecting a Mutation with the set removed from the name, scalarHolder.
-50| type ScalarHolder       |   "HH:mm:ss"                                              |   Missing Default Time Format description on Output Type
-51| type ScalarHolder       |   "yyyy-MM-dd"                                            |   Missing Default Date Format description on Output Type
-52| type ScalarHolder       |   "yyyy-MM-dd'T'HH:mm:ss"                                 |   Missing Default DateTime Format description on Output Type
-53| type ScalarHolder       |   "This is another time (HH:mm:ss)"                       |   Missing Default Time Format description (appended) on Output Type
-54| type ScalarHolder       |   "This is another date (yyyy-MM-dd)"                     |   Missing Default Date Format description (appended) on Output Type
-55| type ScalarHolder       |   "This is another datetime (yyyy-MM-dd'T'HH:mm:ss)"      |   Missing Default DateTime Format description (appended) on Output Type
-56| type ScalarHolder       |   "This is a formatted time (hh:mm:ss)"                   |   Missing Formatted Time Format description (appended) on Output Type
-57| type ScalarHolder       |   "This is a formatted date (MM dd yyyy)"                 |   Missing Formatted Date Format description (appended) on Output Type
-58| type ScalarHolder       |   "This is a formatted datetime (MM dd yyyy 'at' hh:mm:ss)"|   Missing Formatted DateTime Format description (appended) on Output Type
-59| type ScalarHolder       |   "#0.0 en-GB"                                            |   Missing Number Format description on Output Type
-60| type ScalarHolder       |   "This is a formatted number (#0.0 en-GB)"               |   Missing Number Format description (appended) on Output Type
-61| type ScalarHolder       |   longPrimitiveId: ID                                     |   Expecting a ID Scalar Type in type ScalarHolder, long
-62| type ScalarHolder       |   intPrimitiveId: ID                                      |   Expecting a ID Scalar Type in type ScalarHolder, int
-63| type ScalarHolder       |   longObjectId: ID                                        |   Expecting a ID Scalar Type in type ScalarHolder, long
-64| type ScalarHolder       |   integerObjectId: ID                                     |   Expecting a ID Scalar Type in type ScalarHolder, Integer
-65| type ScalarHolder       |   uuidId: ID                                              |   Expecting a ID Scalar Type in type ScalarHolder, UUID
-66| input BasicMessageInput |   message: String                                         |   Expecting a BasicMessageInput from @Input
-67| input BasicMessageInput |   countdownPlace: CountDown                               |   Expecting a BasicMessageInput from @Input
-68| type BasicMessage       |   message: String                                         |   Expecting a BasicMessage from @Type
-69| enum CountDown          |   THREE                                                   |   Expecting a CountDown from @Enum
-70| interface Basic         |   message: String                                         |   Expecting a String argument called "message" in @Interface("MyInterface") BasicInterface
+1|  type ScalarHolder       |   bigDecimalObject: BigDecimal                                                                                            |   Expecting a BigDecimal Scalar Type in type ScalarHolder
+2|  type ScalarHolder       |   bigIntegerObject: BigInteger                                                                                            |   Expecting a BigInteger Scalar Type in type ScalarHolder
+3|  type ScalarHolder       |   booleanObject: Boolean                                                                                                  |   Expecting a Boolean Scalar Type in type ScalarHolder
+4|  type ScalarHolder       |   booleanPrimitive: Boolean!                                                                                              |   Expecting a non null Boolean Scalar Type in type ScalarHolder
+5|  type ScalarHolder       |   byteObject: Int                                                                                                         |   Expecting a Int Scalar Type (for Byte Java Type) in type ScalarHolder
+6|  type ScalarHolder       |   bytePrimitive: Int!                                                                                                     |   Expecting a non null Int Scalar Type (for byte Java Type) in type ScalarHolder
+7|  type ScalarHolder       |   charObject: String                                                                                                      |   Expecting a String Scalar (for Java Char) Type in type ScalarHolder
+8|  type ScalarHolder       |   charPrimitive: String!                                                                                                  |   Expecting a non null String Scalar (for Java char) Type in type ScalarHolder
+9|  type ScalarHolder       |   dateObject: Date                                                                                                        |   Expecting a Date Scalar Type in type ScalarHolder
+10| type ScalarHolder       |   dateTimeObject: DateTime                                                                                                |   Expecting a DateTime Scalar Type in type ScalarHolder
+11| type ScalarHolder       |   doubleObject: Float                                                                                                     |   Expecting a Float Scalar Type in type ScalarHolder
+12| type ScalarHolder       |   doublePrimitive: Float!                                                                                                 |   Expecting a non null Float Scalar Type in type ScalarHolder
+13| type ScalarHolder       |   floatObject: Float                                                                                                      |   Expecting a Float Scalar Type in type ScalarHolder
+14| type ScalarHolder       |   floatPrimitive: Float!                                                                                                  |   Expecting a non null Float Scalar Type in type ScalarHolder
+15| type ScalarHolder       |   id: ID                                                                                                                  |   Expecting a ID Scalar Type in type ScalarHolder
+16| type ScalarHolder       |   intObject: Int                                                                                                          |   Expecting a Int Scalar Type in type ScalarHolder
+17| type ScalarHolder       |   intPrimitive: Int!                                                                                                      |   Expecting a non null Int Scalar Type in type ScalarHolder
+18| type ScalarHolder       |   longObject: BigInteger                                                                                                  |   Expecting a BigInteger Scalar (for Java Long) Type in type ScalarHolder
+19| type ScalarHolder       |   longPrimitive: BigInteger!                                                                                              |   Expecting a non null BigInteger (for Java long) Scalar Type in type ScalarHolder
+20| type ScalarHolder       |   shortObject: Int                                                                                                        |   Expecting a Int Scalar Type (for Short Java Type) in type ScalarHolder
+21| type ScalarHolder       |   shortPrimitive: Int!                                                                                                    |   Expecting a non null Int Scalar Type (for short Java Type) in type ScalarHolder
+22| type ScalarHolder       |   stringObject: String                                                                                                    |   Expecting a String Scalar Type in type ScalarHolder
+23| type ScalarHolder       |   charArray: [String]                                                                                                     |   Expecting a String Array Scalar (for Java Char[]) Type in type ScalarHolder
+24| type ScalarHolder       |   timeObject: Time                                                                                                        |   Expecting a Time Scalar Type in type ScalarHolder
+25| type Query              |   testBigDecimalObject: BigDecimal                                                                                        |   Expecting a BigDecimal Scalar Type in type Query
+26| type Query              |   testBigIntegerObject: BigInteger                                                                                        |   Expecting a BigInteger Scalar Type in type Query
+27| type Query              |   booleanObject: Boolean                                                                                                  |   Expecting a Boolean Scalar Type in type Query, with the is removed from the name
+28| type Query              |   booleanPrimitive: Boolean!                                                                                              |   Expecting a non null Boolean Scalar Type in type Query, with the is removed from the name
+29| type Query              |   testByteObject: Int                                                                                                     |   Expecting a Int Scalar Type (for Byte Java Type) in type Query
+30| type Query              |   testBytePrimitive: Int!                                                                                                 |   Expecting a non null Int Scalar Type (for byte Java Type) in type Query
+31| type Query              |   testCharObject: String                                                                                                  |   Expecting a String Scalar (for Java Char) Type in type Query
+32| type Query              |   testCharPrimitive: String!                                                                                              |   Expecting a non null String Scalar (for Java char) Type in type Query
+33| type Query              |   testDateObject: Date                                                                                                    |   Expecting a Date Scalar Type in type Query
+34| type Query              |   testDateTimeObject: DateTime                                                                                            |   Expecting a DateTime Scalar Type in type Query
+35| type Query              |   testDoubleObject: Float                                                                                                 |   Expecting a Float Scalar Type in type Query
+36| type Query              |   testDoublePrimitive: Float!                                                                                             |   Expecting a non null Float Scalar Type in type Query
+37| type Query              |   testFloatObject: Float                                                                                                  |   Expecting a Float Scalar Type in type Query
+38| type Query              |   testFloatPrimitive: Float!                                                                                              |   Expecting a non null Float Scalar Type in type Query
+39| type Query              |   testId: ID                                                                                                              |   Expecting a ID Scalar Type in type Query
+40| type Query              |   testIntObject: Int                                                                                                      |   Expecting a Int Scalar Type in type Query
+41| type Query              |   testIntPrimitive: Int!                                                                                                  |   Expecting a non null Int Scalar Type in type Query
+42| type Query              |   testLongObject: BigInteger                                                                                              |   Expecting a BigInteger Scalar (for Java Long) Type in type Query
+43| type Query              |   testLongPrimitive: BigInteger!                                                                                          |   Expecting a non null BigInteger Scalar (for Java long) Type in type Query
+44| type Query              |   shortObject: Int                                                                                                        |   Expecting a Int Scalar Type (for Short Java type) in type Query, with the get removed from the name
+45| type Query              |   shortPrimitive: Int!                                                                                                    |   Expecting a non null Int Scalar Type (for short Java type) in type Query, with the get removed from the name
+46| type Query              |   testStringObject: String                                                                                                |   Expecting a String Scalar Type in type Query
+47| type Query              |   testCharArray: [String]                                                                                                 |   Expecting a non null Stirng Array (for Java Char[]) Scalar Type in type Query
+48| type Query              |   testTimeObject: Time                                                                                                    |   Expecting a Time Scalar Type in type Query
+49| type Mutation           |   scalarHolder(arg0: ScalarHolderInput): ScalarHolder 'OR' scalarHolder(scalarHolder: ScalarHolderInput): ScalarHolder    |   Expecting a Mutation with the set removed from the name, scalarHolder.
+50| type ScalarHolder       |   "HH:mm:ss" 'OR' "ISO-8601"                                                                                              |   Missing Default Time Format description on Output Type
+51| type ScalarHolder       |   "yyyy-MM-dd"  'OR' "ISO-8601"                                                                                           |   Missing Default Date Format description on Output Type
+52| type ScalarHolder       |   "yyyy-MM-dd'T'HH:mm:ss" 'OR' "ISO-8601"                                                                                 |   Missing Default DateTime Format description on Output Type
+53| type ScalarHolder       |   "This is another time (HH:mm:ss)" 'OR' "This is another time (ISO-8601)"                                                |   Missing Default Time Format description (appended) on Output Type
+54| type ScalarHolder       |   "This is another date (yyyy-MM-dd)" 'OR' "This is another date (ISO-8601)"                                              |   Missing Default Date Format description (appended) on Output Type
+55| type ScalarHolder       |   "This is another datetime (yyyy-MM-dd'T'HH:mm:ss)" 'OR' "This is another datetime (ISO-8601)"                           |   Missing Default DateTime Format description (appended) on Output Type
+56| type ScalarHolder       |   "This is a formatted time (hh:mm:ss)"                                                                                   |   Missing Formatted Time Format description (appended) on Output Type
+57| type ScalarHolder       |   "This is a formatted date (MM dd yyyy)"                                                                                 |   Missing Formatted Date Format description (appended) on Output Type
+58| type ScalarHolder       |   "This is a formatted datetime (MM dd yyyy 'at' hh:mm:ss)"                                                               |   Missing Formatted DateTime Format description (appended) on Output Type
+59| type ScalarHolder       |   "#0.0 en-GB"                                                                                                            |   Missing Number Format description on Output Type
+60| type ScalarHolder       |   "This is a formatted number (#0.0 en-GB)"                                                                               |   Missing Number Format description (appended) on Output Type
+61| type ScalarHolder       |   longPrimitiveId: ID                                                                                                     |   Expecting a ID Scalar Type in type ScalarHolder, long
+62| type ScalarHolder       |   intPrimitiveId: ID                                                                                                      |   Expecting a ID Scalar Type in type ScalarHolder, int
+63| type ScalarHolder       |   longObjectId: ID                                                                                                        |   Expecting a ID Scalar Type in type ScalarHolder, long
+64| type ScalarHolder       |   integerObjectId: ID                                                                                                     |   Expecting a ID Scalar Type in type ScalarHolder, Integer
+65| type ScalarHolder       |   uuidId: ID                                                                                                              |   Expecting a ID Scalar Type in type ScalarHolder, UUID
+66| input BasicMessageInput |   message: String                                                                                                         |   Expecting a BasicMessageInput from @Input
+67| input BasicMessageInput |   countdownPlace: CountDown                                                                                               |   Expecting a BasicMessageInput from @Input
+68| type BasicMessage       |   message: String                                                                                                         |   Expecting a BasicMessage from @Type
+69| enum CountDown          |   THREE                                                                                                                   |   Expecting a CountDown from @Enum
+70| interface Basic         |   message: String                                                                                                         |   Expecting a String argument called "message" in @Interface("MyInterface") BasicInterface

--- a/tck/src/main/resources/tests/schemaTests.csv
+++ b/tck/src/main/resources/tests/schemaTests.csv
@@ -30,70 +30,76 @@
 19| enum ShirtSize      |   HULK                                                    |   Missing expected enum value, "HULK"
     
 # testDateScalarUsedForLocalDate
-20|input SuperHeroInput|   dateOfLastCheckin: Date                                 |   Missing or incorrect Scalar type in "SuperHeroInput" field "dateOfLastCheckin"
-21|type SuperHero      |   dateOfLastCheckin: Date                                 |   Missing or incorrect Scalar type in "SuperHero" field "dateOfLastCheckin"
+20|input SuperHeroInput|   !dateOfLastCheckin: Date                                 |   Transformed Date Scalar type in "SuperHeroInput" field "dateOfLastCheckin" should not be Date
+21|type SuperHero      |   !dateOfLastCheckin: Date                                 |   Transformed Date Scalar type in "SuperHero" field "dateOfLastCheckin" should not be Date
+22|input SuperHeroInput|   dateOfLastCheckin: String 'OR' dateOfLastCheckin:        |   Missing or incorrect Scalar type in "SuperHeroInput" field "dateOfLastCheckin"
+23|type SuperHero      |   dateOfLastCheckin: String 'OR' dateOfLastCheckin:        |   Missing or incorrect Scalar type in "SuperHero" field "dateOfLastCheckin"
     
 # testTimeScalarUsedForLocalTime
-22|input SuperHeroInput|   patrolStartTime: Time                                   |   Missing or incorrect Scalar type in "SuperHeroInput" field "patrolStartTime"
-23|type SuperHero      |   patrolStartTime: Time                                   |   Missing or incorrect Scalar type in "SuperHero" field "patrolStartTime"
+24|input SuperHeroInput|   !patrolStartTime: Time                                  |   Transformed Time Scalar type in "SuperHeroInput" field "patrolStartTime" should not be Time
+25|type SuperHero      |   !patrolStartTime: Time                                  |   Transformed Time Scalar type in "SuperHero" field "patrolStartTime" should not be Time
+26|input SuperHeroInput|   patrolStartTime: String 'OR' patrolStartTime:           |   Missing or incorrect Scalar type in "SuperHeroInput" field "patrolStartTime"
+27|type SuperHero      |   patrolStartTime: String 'OR' patrolStartTime:           |   Missing or incorrect Scalar type in "SuperHero" field "patrolStartTime"
     
 # testDateTimeScalarUsedForLocalDateTime
-24|input SuperHeroInput|   timeOfLastBattle: DateTime                              |   Missing or incorrect Scalar type in "SuperHeroInput" field "timeOfLastBattle"
-25|type SuperHero      |   timeOfLastBattle: DateTime                              |   Missing or incorrect Scalar type in "SuperHero" field "timeOfLastBattle"
+28|input SuperHeroInput|   !timeOfLastBattle: DateTime                             |   Transformed DateTime Scalar type in "SuperHeroInput" field "timeOfLastBattle" should not be DateTime
+29|type SuperHero      |   !timeOfLastBattle: DateTime                             |   Transformed DateTime Scalar type in "SuperHero" field "timeOfLastBattle" should not be DateTime
+30|input SuperHeroInput|   timeOfLastBattle: String 'OR' timeOfLastBattle:         |   Missing or incorrect Scalar type in "SuperHeroInput" field "timeOfLastBattle"
+31|type SuperHero      |   timeOfLastBattle: String 'OR' timeOfLastBattle:         |   Missing or incorrect Scalar type in "SuperHero" field "timeOfLastBattle"
     
 # testSchemaContainsDescriptionForQueryMethods
-26|type Query          |   "List all super heroes in the database"                 |   Missing description on Query Method
+32|type Query          |   "List all super heroes in the database"                 |   Missing description on Query Method
     
 # testSchemaContainsDescriptionForMutationMethods
-27|type Mutation       |   "Removes a hero... permanently..."                      |   Missing description on Mutation Method
+33|type Mutation       |   "Removes a hero... permanently..."                      |   Missing description on Mutation Method
     
 # testSchemaContainsDescriptionForEntityTypes
-28|                    |   "Something of use to a super hero"                      |   Missing description on Entity type
+34|                    |   "Something of use to a super hero"                      |   Missing description on Entity type
 
 # testSchemaContainsDescriptionForInputTypes
 
 # testSchemaContainsDescriptionForArguments
-29|type Query          |   "Super hero name, not real name"                        |   Missing description on Query Argument
+35|type Query          |   "Super hero name, not real name"                        |   Missing description on Query Argument
 
 # testSchemaContainsDescriptionForOutputTypeFields
-30|type SuperHero      |   "Super hero name/nickname"                              |   Missing description on Output Type
-31|type SuperHero      |   "Location where you are most likely to find this hero"  |   Missing description on Output Type  
+36|type SuperHero      |   "Super hero name/nickname"                              |   Missing description on Output Type
+37|type SuperHero      |   "Location where you are most likely to find this hero"  |   Missing description on Output Type  
 
 # testSchemaContainsDescriptionForInputTypeFields
-32|input SuperHeroInput|   "Super hero name/nickname"                              |   Missing description on Input Type
-33|input SuperHeroInput|   "Powers that make this hero super"                      |   Missing description on Input Type
+38|input SuperHeroInput|   "Super hero name/nickname"                              |   Missing description on Input Type
+39|input SuperHeroInput|   "Powers that make this hero super"                      |   Missing description on Input Type
 
 # testSchemaOutputTypeFieldsContainsDescriptionFromJsonbDateFormat
-34|type SuperHero      |   "MM/dd/yyyy"                                            |   Missing Date Format description on Output Type
-35|type SuperHero      |   "HH:mm"                                                 |   Missing Time Format description on Output Type
-36|type SuperHero      |   "HH:mm:ss dd-MM-yyyy"                                   |   Missing DateTime Format description on Output Type
+40|type SuperHero      |   "MM/dd/yyyy"                                            |   Missing Date Format description on Output Type
+41|type SuperHero      |   "HH:mm"                                                 |   Missing Time Format description on Output Type
+42|type SuperHero      |   "HH:mm:ss dd-MM-yyyy"                                   |   Missing DateTime Format description on Output Type
   
 # testSchemaInputTypeFieldsContainsDescriptionFromJsonbDateFormat
-37|input SuperHeroInput|   "MM/dd/yyyy"                                            |   Missing Date Format description on Input Type
-38|input SuperHeroInput|   "HH:mm"                                                 |   Missing Time Format description on Input Type
-39|input SuperHeroInput|   "HH:mm:ss dd-MM-yyyy"                                   |   Missing DateTime Format description on Input Type
+43|input SuperHeroInput|   "MM/dd/yyyy"                                            |   Missing Date Format description on Input Type
+44|input SuperHeroInput|   "HH:mm"                                                 |   Missing Time Format description on Input Type
+45|input SuperHeroInput|   "HH:mm:ss dd-MM-yyyy"                                   |   Missing DateTime Format description on Input Type
 
 # testSchemaContainsDefaultValueOnEntityField
-40|input ItemInput     |   supernatural: Boolean = false                           |   Missing default value in Input boolean field
+46|input ItemInput     |   supernatural: Boolean = false                           |   Missing default value in Input boolean field
 
 # testSchemaContainsDefaultValueOnEntitySetter
-41|input ItemInput     |   description: String = "An unidentified item"            |   Missing default value in Input String field
+47|input ItemInput     |   description: String = "An unidentified item"            |   Missing default value in Input String field
 
 # testWithArgumentNameAndDefaultValue
-42|type Query          |   allHeroesIn(city: String = "New York, NY"): [SuperHero] |   Missing default value on argument
-43|type Query          |   allHeroesInTeam(team: String): [SuperHero]              |   Missing argument on Query
+48|type Query          |   allHeroesIn(city: String = "New York, NY"): [SuperHero] |   Missing default value on argument
+49|type Query          |   allHeroesInTeam(team: String): [SuperHero]              |   Missing argument on Query
 
 # testSourceFieldInType
-44|type SuperHero      |   currentLocation: String                                 |   Expecting a currentLocation field in SuperHero due to Source annotation
-45|type Query          |   currentLocation(superHero: SuperHeroInput): String      |   Expecting a currentLocation query in Query to Source annotation
-46|type SuperHero      |   secretToken(maskFirstPart: Boolean = true): TopSecretToken      |   Expecting a secretToken field with a boolean argument in SuperHero due to Source annotation
-47|type Query          |   !secretToken(maskFirstPart: Boolean = true): TopSecretToken     |   Not expecting a secretToken query in Query
-48|type TopSecretToken |   value: String                                           |   Expecting a TopSecretToken type, with a String value field 
+50|type SuperHero      |   currentLocation: String                                 |   Expecting a currentLocation field in SuperHero due to Source annotation
+51|type Query          |   currentLocation(superHero: SuperHeroInput): String      |   Expecting a currentLocation query in Query to Source annotation
+52|type SuperHero      |   secretToken(maskFirstPart: Boolean = true): TopSecretToken      |   Expecting a secretToken field with a boolean argument in SuperHero due to Source annotation
+53|type Query          |   !secretToken(maskFirstPart: Boolean = true): TopSecretToken     |   Not expecting a secretToken query in Query
+54|type TopSecretToken |   value: String                                           |   Expecting a TopSecretToken type, with a String value field 
 
 # testGetAndSetNotGetterAndSetter
-49|type Query          |   getaway: String                                         |   Expecting a getaway query where the get is not removed
-50|type Mutation       |   settlement: String                                      |   Expecting a settlement mutation where the set is not removed
+55|type Query          |   getaway: String                                         |   Expecting a getaway query where the get is not removed
+56|type Mutation       |   settlement: String                                      |   Expecting a settlement mutation where the set is not removed
 
 # testDescription
-51|type Query          |   "Testing the blacklist of Checked Exceptions"           |   Expecting a description for the exportToFile query
-52|type Query          |   "Super hero name, not real name"                        |   Expecting a description for the name parameter on the exportToFile query
+57|type Query          |   "Testing the blacklist of Checked Exceptions"           |   Expecting a description for the exportToFile query
+58|type Query          |   "Super hero name, not real name"                        |   Expecting a description for the name parameter on the exportToFile query


### PR DESCRIPTION
This PR fixes issues #225 and #209.

As discussed, when formatting is added to a Date or Number Type, the resulting type in the response (or input) is a String and the Type in the Schema is either a String or a custom scalar type (implementation specific)

The description for dates can now be either the text `ISO-8601` or like it is currently the formatting.

I'll do a separate PR to get this into master as well