### PR TITLE
Fix #304 

### DIFF
--- a/tck/src/main/java/org/eclipse/microprofile/graphql/tck/dynamic/ExecutionDynamicTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/graphql/tck/dynamic/ExecutionDynamicTest.java
@@ -144,7 +144,6 @@ public class ExecutionDynamicTest extends Arquillian {
                     listExceptions.forEach(ex -> sb.append(ex.getMessage()).append('\n'));
                     Assert.fail(sb.toString());
                 }
-
             } else {
                 Assert.assertEquals(httpResponse.status, testData.getExpectedHttpStatusCode(),httpResponse.getContent());
             }

--- a/tck/src/main/java/org/eclipse/microprofile/graphql/tck/dynamic/ExecutionDynamicTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/graphql/tck/dynamic/ExecutionDynamicTest.java
@@ -29,6 +29,7 @@ import java.io.StringReader;
 import java.net.HttpURLConnection;
 import java.net.ProtocolException;
 import java.net.URI;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
@@ -122,14 +123,28 @@ public class ExecutionDynamicTest extends Arquillian {
                 if(isValidInput(testData.getCleanup())){
                     postHTTPRequest(testData.getCleanup(),testData.getVariables(),httpHeaders);
                 }
-                
-                // Compare to expected output
-                try{
-                    JSONAssert.assertEquals(testData.getFailMessage(),testData.getOutput(), this.currentOutput, testData.beStrict());
-                } catch (JSONException ex) {
-                    clearGlobals();
-                    Assert.fail(ex.getMessage());
+
+                boolean success = false;
+                ArrayList<Throwable> listExceptions = new ArrayList<>();
+
+                // Compare to expected output and pass if at least one of the output files match
+                for (String output : testData.getOutput()) {
+                    try {
+                        JSONAssert.assertEquals(testData.getFailMessage(), output, this.currentOutput, testData.beStrict());
+                        success = true;
+                        break;
+                    } catch (AssertionError | JSONException ex) {
+                        // don't raise assertion failure as this is checked below
+                        listExceptions.add(ex);
+                    }
                 }
+                if (!success) {
+                    clearGlobals();
+                    StringBuilder sb = new StringBuilder();
+                    listExceptions.forEach(ex -> sb.append(ex.getMessage()).append('\n'));
+                    Assert.fail(sb.toString());
+                }
+
             } else {
                 Assert.assertEquals(httpResponse.status, testData.getExpectedHttpStatusCode(),httpResponse.getContent());
             }

--- a/tck/src/main/java/org/eclipse/microprofile/graphql/tck/dynamic/execution/GraphQLTestDataProvider.java
+++ b/tck/src/main/java/org/eclipse/microprofile/graphql/tck/dynamic/execution/GraphQLTestDataProvider.java
@@ -139,54 +139,56 @@ public class GraphQLTestDataProvider {
                 if(!Files.isDirectory(file)){
                     String filename = file.getFileName().toString();
 
-                    switch (filename) {
-                        case "input.graphql":
-                            {
-                                String content = getFileContent(file);
-                                testData.setInput(content);
+                    if (filename.matches("output.*\\.json")){
+                        // Special case to cater for multiple output*.json files where the
+                        // test will pass on the first file content that matches.
+                        // If no content matches, then the test will fail.
+                        String content = getFileContent(file);
+                        testData.addOutput(content);
+                    } else {
+                        switch (filename) {
+                            case "input.graphql":
+                                {
+                                    String content = getFileContent(file);
+                                    testData.setInput(content);
+                                    break;
+                                }
+                            case "httpHeader.properties":
+                                {
+                                    Properties properties = new Properties();
+                                    properties.load(Files.newInputStream(file));
+                                    testData.setHttpHeaders(properties);
+                                    break;
+                                }
+                            case "variables.json":
+                                {
+                                    String content = getFileContent(file);
+                                    testData.setVariables(toJsonObject(content));
+                                    break;
+                                }
+                            case "test.properties":
+                                {
+                                    Properties properties = new Properties();
+                                    properties.load(Files.newInputStream(file));
+                                    testData.setProperties(properties);
+                                    break;
+                                }
+                            case "cleanup.graphql":
+                                {
+                                    String content = getFileContent(file);
+                                    testData.setCleanup(content);
+                                    break;
+                                }
+                            case "prepare.graphql":
+                                {
+                                    String content = getFileContent(file);
+                                    testData.setPrepare(content);
+                                    break;
+                                }
+                            default:
+                                LOG.log(Level.WARNING, "Ignoring unknown file {0}", filename);
                                 break;
-                            }
-                        case "httpHeader.properties":
-                            {
-                                Properties properties = new Properties();
-                                properties.load(Files.newInputStream(file));
-                                testData.setHttpHeaders(properties);
-                                break;
-                            }    
-                        case "output.json":
-                            {
-                                String content = getFileContent(file);
-                                testData.setOutput(content);
-                                break;
-                            }
-                        case "variables.json":
-                            {
-                                String content = getFileContent(file);
-                                testData.setVariables(toJsonObject(content));
-                                break;
-                            }
-                        case "test.properties":
-                            {
-                                Properties properties = new Properties();
-                                properties.load(Files.newInputStream(file));
-                                testData.setProperties(properties);
-                                break;
-                            }
-                        case "cleanup.graphql":
-                            {
-                                String content = getFileContent(file);
-                                testData.setCleanup(content);
-                                break;
-                            }    
-                        case "prepare.graphql":
-                            {
-                                String content = getFileContent(file);
-                                testData.setPrepare(content);
-                                break;
-                            }    
-                        default:
-                            LOG.log(Level.WARNING, "Ignoring unknown file {0}", filename);
-                            break;
+                        }
                     }
                 }
                 return FileVisitResult.CONTINUE;

--- a/tck/src/main/java/org/eclipse/microprofile/graphql/tck/dynamic/execution/PrintUtil.java
+++ b/tck/src/main/java/org/eclipse/microprofile/graphql/tck/dynamic/execution/PrintUtil.java
@@ -71,7 +71,13 @@ public class PrintUtil {
             sw.write("\n\n");
             sw.write("http headers input = " + testData.getHttpHeaders());
             sw.write("\n\n");
-            sw.write("expected output = " + prettyJson(testData.getOutput()));
+
+            if (testData.getOutput().size() == 1) {
+                sw.write("expected output = " + prettyJson(testData.getOutput().iterator().next()));
+            } else {
+                sw.write("expected output was either of the following = " + String.join("\nOR\n", testData.getOutput()));
+            }
+
             sw.write("\n\n");
             sw.write("received output = " +  prettyJson(output));
             sw.write("\n\n");

--- a/tck/src/main/java/org/eclipse/microprofile/graphql/tck/dynamic/execution/TestData.java
+++ b/tck/src/main/java/org/eclipse/microprofile/graphql/tck/dynamic/execution/TestData.java
@@ -30,9 +30,9 @@ import javax.json.JsonObject;
 public class TestData {
     private String name;
     private String input;
-    private Properties  httpHeaders;
+    private Properties httpHeaders;
     private Set<String> output;
-    private JsonObject  variables;
+    private JsonObject variables;
     private String prepare;
     private String cleanup;
     private Properties properties;

--- a/tck/src/main/java/org/eclipse/microprofile/graphql/tck/dynamic/execution/TestData.java
+++ b/tck/src/main/java/org/eclipse/microprofile/graphql/tck/dynamic/execution/TestData.java
@@ -17,8 +17,10 @@
  */
 package org.eclipse.microprofile.graphql.tck.dynamic.execution;
 
+import java.util.HashSet;
 import java.util.Objects;
 import java.util.Properties;
+import java.util.Set;
 import javax.json.JsonObject;
 
 /**
@@ -28,9 +30,9 @@ import javax.json.JsonObject;
 public class TestData {
     private String name;
     private String input;
-    private Properties httpHeaders;
-    private String output;
-    private JsonObject variables;
+    private Properties  httpHeaders;
+    private Set<String> output;
+    private JsonObject  variables;
     private String prepare;
     private String cleanup;
     private Properties properties;
@@ -41,12 +43,13 @@ public class TestData {
     
     public TestData(String name){
         this.name = name;
+        this.output = new HashSet<>();
     }
 
     public TestData(String name, 
                     String input, 
                     Properties httpHeaders, 
-                    String output, 
+                    Set<String> output,
                     JsonObject variables, 
                     String prepare, 
                     String cleanup, 
@@ -74,7 +77,7 @@ public class TestData {
         return httpHeaders;
     }
 
-    public String getOutput() {
+    public Set<String> getOutput() {
         return output;
     }
 
@@ -106,8 +109,12 @@ public class TestData {
         this.httpHeaders = httpHeaders;
     }
 
-    public void setOutput(String output) {
+    public void setOutput(Set<String> output) {
         this.output = output;
+    }
+
+    public void addOutput(String output) {
+        this.output.add(output);
     }
 
     public void setVariables(JsonObject variables) {

--- a/tck/src/main/resources/tests/basicScalar/output2.json
+++ b/tck/src/main/resources/tests/basicScalar/output2.json
@@ -43,11 +43,11 @@
             "dateObject": "2019-10-23",
             "anotherDateObject": "2019-10-23",
             "formattedDateObject": "10 23 2019",
-            "timeObject": "11:46:34.263",
-            "anotherTimeObject": "11:46:34.263",
+            "timeObject": "11:46:34",
+            "anotherTimeObject": "11:46:34",
             "formattedTimeObject": "11:46:34",
-            "dateTimeObject": "2019-10-23T11:46:34.263",
-            "anotherDateTimeObject": "2019-10-23T11:46:34.263",
+            "dateTimeObject": "2019-10-23T11:46:34",
+            "anotherDateTimeObject": "2019-10-23T11:46:34",
             "formattedDateTimeObject": "10 23 2019 at 11:46:34",
             "id": "123456789"
         }


### PR DESCRIPTION
Add the ability for a test to match one of many output*.json files.
Signed-off-by: Tim Middleton (Software Engineer) <tim.middleton@oracle.com>