### PR TITLE
Fix default value non ordered alternative (master)

### DIFF
--- a/server/tck/src/main/resources/tests/schemaTests.csv
+++ b/server/tck/src/main/resources/tests/schemaTests.csv
@@ -105,4 +105,4 @@
 58|type Query          |   "Super hero name, not real name"                        |   Expecting a description for the name parameter on the exportToFile query
 
 # testJsonDefault
-59|type Mutation       |   id : 1000 'AND' name : "Cape" 'AND' powerLevel : 3 'AND' height : 1.2 'AND' weight : 0.3 'AND' supernatural : false | Expecting a default value for item for provisionHero
+59|type Mutation       |   provisionHero(hero: String, item: ItemInput = { id: 1000, name: "Cape", powerLevel: 3, height: 1.2, weight: 0.3, supernatural: false, dateCreated: "19 February 1900 at 12:00 in Africa/Johannesburg", dateLastUsed: "29 Jan 2020 at 09:45 in zone +0200"} 'OR' provisionHero(hero: String, item: ItemInput = {dateCreated : "19 February 1900 at 12:00 in Africa/Johannesburg", dateLastUsed : "29 Jan 2020 at 09:45 in zone +0200", height : 1.2, id : 1000, name : "Cape", powerLevel : 3, supernatural : false, weight : 0.3}) | Expecting a default value for item for provisionHero


### PR DESCRIPTION
Add the correct alternative for default object parameter schema test.
Signed-off-by:Phillip Kruger <phillip.kruger@gmail.com>