### PR TITLE
[386] Move to Jakarta EE 9.1 dependencies

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2020 Contributors to the Eclipse Foundation
+  ~ Copyright (c) 2020, 2021 Contributors to the Eclipse Foundation
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.eclipse.microprofile.graphql</groupId>
         <artifactId>microprofile-graphql-parent</artifactId>
-        <version>1.1.1-SNAPSHOT</version>
+        <version>2.0-SNAPSHOT</version>
         <relativePath>../</relativePath>
     </parent>
     

--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2020 Contributors to the Eclipse Foundation
+  ~ Copyright (c) 2020, 2021 Contributors to the Eclipse Foundation
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@
 
     <groupId>org.eclipse.microprofile.graphql</groupId>
     <artifactId>microprofile-graphql-parent</artifactId>
-    <version>1.1.1-SNAPSHOT</version>
+    <version>2.0-SNAPSHOT</version>
 
     <name>MicroProfile GraphQL</name>
 
@@ -32,7 +32,7 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
 
-        <cdi-api.version>2.0.2</cdi-api.version>
+        <cdi-api.version>3.0.0</cdi-api.version>
 
         <testng.version>7.0.0</testng.version>
         <arquillian.version>1.6.0.Final</arquillian.version>
@@ -228,7 +228,7 @@
                                     <property name="format" value="^_?[A-Z][a-zA-Z0-9]*$|packageinfo" />
                                 </module>
                                 <module name="AvoidStarImport">
-                                    <property name="excludes" value="java.io,java.net,java.util,javax.enterprise.inject.spi,javax.enterprise.context" />
+                                    <property name="excludes" value="java.io,java.net,java.util,jakarta.enterprise.inject.spi,jakarta.enterprise.context" />
                                 </module>
                                 <module name="IllegalImport" />
                                 <module name="RedundantImport" />

--- a/spec/pom.xml
+++ b/spec/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2020 Contributors to the Eclipse Foundation
+  ~ Copyright (c) 2020, 2021 Contributors to the Eclipse Foundation
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.eclipse.microprofile.graphql</groupId>
         <artifactId>microprofile-graphql-parent</artifactId>
-        <version>1.1.1-SNAPSHOT</version>
+        <version>2.0-SNAPSHOT</version>
         <relativePath>../</relativePath>
     </parent>
 
@@ -120,4 +120,3 @@
     </build>
 
 </project>
-

--- a/tck/pom.xml
+++ b/tck/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2020 Contributors to the Eclipse Foundation
+  ~ Copyright (c) 2020, 2021 Contributors to the Eclipse Foundation
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.eclipse.microprofile.graphql</groupId>
         <artifactId>microprofile-graphql-parent</artifactId>
-        <version>1.1.1-SNAPSHOT</version>
+        <version>2.0-SNAPSHOT</version>
         <relativePath>../</relativePath>
     </parent>
 
@@ -29,9 +29,9 @@
     <description>Code-first GraphQL APIs for MicroProfile :: TCK</description>
 
     <properties>
-        <jsonp-api.version>1.1.6</jsonp-api.version>
-        <jsonb-api.version>1.0.2</jsonb-api.version>
-        <commons-io.version>2.6</commons-io.version>
+        <jsonp-api.version>2.0.1</jsonp-api.version>
+        <jsonb-api.version>2.0.0</jsonb-api.version>
+        <commons-io.version>2.11.0</commons-io.version>
         <jsonassert.version>1.5.0</jsonassert.version>
     </properties>
 

--- a/tck/src/main/java/org/eclipse/microprofile/graphql/tck/apps/basic/api/ScalarHolder.java
+++ b/tck/src/main/java/org/eclipse/microprofile/graphql/tck/apps/basic/api/ScalarHolder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ * Copyright (c) 2020, 2021 Contributors to the Eclipse Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,8 +21,8 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.UUID;
-import javax.json.bind.annotation.JsonbDateFormat;
-import javax.json.bind.annotation.JsonbNumberFormat;
+import jakarta.json.bind.annotation.JsonbDateFormat;
+import jakarta.json.bind.annotation.JsonbNumberFormat;
 
 import org.eclipse.microprofile.graphql.DefaultValue;
 import org.eclipse.microprofile.graphql.Description;

--- a/tck/src/main/java/org/eclipse/microprofile/graphql/tck/apps/basic/api/ScalarTestApi.java
+++ b/tck/src/main/java/org/eclipse/microprofile/graphql/tck/apps/basic/api/ScalarTestApi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ * Copyright (c) 2020, 2021 Contributors to the Eclipse Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +20,7 @@ import java.math.BigInteger;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
-import javax.json.bind.annotation.JsonbProperty;
+import jakarta.json.bind.annotation.JsonbProperty;
 import org.eclipse.microprofile.graphql.DateFormat;
 import org.eclipse.microprofile.graphql.Description;
 import org.eclipse.microprofile.graphql.GraphQLApi;

--- a/tck/src/main/java/org/eclipse/microprofile/graphql/tck/apps/superhero/api/HeroFinder.java
+++ b/tck/src/main/java/org/eclipse/microprofile/graphql/tck/apps/superhero/api/HeroFinder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ * Copyright (c) 2020, 2021 Contributors to the Eclipse Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,9 +33,9 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
-import javax.inject.Inject;
-import javax.json.bind.annotation.JsonbDateFormat;
-import javax.json.bind.annotation.JsonbNumberFormat;
+import jakarta.inject.Inject;
+import jakarta.json.bind.annotation.JsonbDateFormat;
+import jakarta.json.bind.annotation.JsonbNumberFormat;
 import org.eclipse.microprofile.graphql.DateFormat;
 
 import org.eclipse.microprofile.graphql.DefaultValue;

--- a/tck/src/main/java/org/eclipse/microprofile/graphql/tck/apps/superhero/db/HeroDatabase.java
+++ b/tck/src/main/java/org/eclipse/microprofile/graphql/tck/apps/superhero/db/HeroDatabase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ * Copyright (c) 2020, 2021 Contributors to the Eclipse Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,11 +24,11 @@ import java.util.List;
 import java.util.ListIterator;
 import java.util.Map;
 
-import javax.enterprise.context.ApplicationScoped;
-import javax.enterprise.context.Initialized;
-import javax.enterprise.event.Observes;
-import javax.json.bind.Jsonb;
-import javax.json.bind.JsonbBuilder;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.Initialized;
+import jakarta.enterprise.event.Observes;
+import jakarta.json.bind.Jsonb;
+import jakarta.json.bind.JsonbBuilder;
 
 import org.eclipse.microprofile.graphql.tck.apps.superhero.model.SuperHero;
 import org.eclipse.microprofile.graphql.tck.apps.superhero.model.Team;

--- a/tck/src/main/java/org/eclipse/microprofile/graphql/tck/apps/superhero/db/HeroLocator.java
+++ b/tck/src/main/java/org/eclipse/microprofile/graphql/tck/apps/superhero/db/HeroLocator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ * Copyright (c) 2020, 2021 Contributors to the Eclipse Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,9 +19,9 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 
-import javax.enterprise.context.ApplicationScoped;
-import javax.enterprise.context.Initialized;
-import javax.enterprise.event.Observes;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.Initialized;
+import jakarta.enterprise.event.Observes;
 
 @ApplicationScoped
 public class HeroLocator {

--- a/tck/src/main/java/org/eclipse/microprofile/graphql/tck/apps/superhero/db/SidekickDatabase.java
+++ b/tck/src/main/java/org/eclipse/microprofile/graphql/tck/apps/superhero/db/SidekickDatabase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ * Copyright (c) 2020, 2021 Contributors to the Eclipse Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,12 +20,12 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 
-import javax.enterprise.context.ApplicationScoped;
-import javax.enterprise.context.Initialized;
-import javax.enterprise.event.Observes;
-import javax.json.bind.Jsonb;
-import javax.json.bind.JsonbBuilder;
-import javax.json.bind.JsonbException;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.Initialized;
+import jakarta.enterprise.event.Observes;
+import jakarta.json.bind.Jsonb;
+import jakarta.json.bind.JsonbBuilder;
+import jakarta.json.bind.JsonbException;
 
 import org.eclipse.microprofile.graphql.tck.apps.superhero.model.Sidekick;
 

--- a/tck/src/main/java/org/eclipse/microprofile/graphql/tck/apps/superhero/model/Item.java
+++ b/tck/src/main/java/org/eclipse/microprofile/graphql/tck/apps/superhero/model/Item.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ * Copyright (c) 2020, 2021 Contributors to the Eclipse Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@ package org.eclipse.microprofile.graphql.tck.apps.superhero.model;
 import java.time.OffsetDateTime;
 import java.time.ZonedDateTime;
 import java.util.Collection;
-import javax.json.bind.annotation.JsonbDateFormat;
+import jakarta.json.bind.annotation.JsonbDateFormat;
 
 import org.eclipse.microprofile.graphql.DefaultValue;
 import org.eclipse.microprofile.graphql.Description;

--- a/tck/src/main/java/org/eclipse/microprofile/graphql/tck/apps/superhero/model/SuperHero.java
+++ b/tck/src/main/java/org/eclipse/microprofile/graphql/tck/apps/superhero/model/SuperHero.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ * Copyright (c) 2020, 2021 Contributors to the Eclipse Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,10 +23,10 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
-import javax.json.bind.annotation.JsonbDateFormat;
-import javax.json.bind.annotation.JsonbNumberFormat;
-import javax.json.bind.annotation.JsonbProperty;
-import javax.json.bind.annotation.JsonbTransient;
+import jakarta.json.bind.annotation.JsonbDateFormat;
+import jakarta.json.bind.annotation.JsonbNumberFormat;
+import jakarta.json.bind.annotation.JsonbProperty;
+import jakarta.json.bind.annotation.JsonbTransient;
 import org.eclipse.microprofile.graphql.DateFormat;
 
 import org.eclipse.microprofile.graphql.Description;

--- a/tck/src/main/java/org/eclipse/microprofile/graphql/tck/apps/superhero/model/Team.java
+++ b/tck/src/main/java/org/eclipse/microprofile/graphql/tck/apps/superhero/model/Team.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ * Copyright (c) 2020, 2021 Contributors to the Eclipse Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@ package org.eclipse.microprofile.graphql.tck.apps.superhero.model;
 import java.time.OffsetTime;
 import java.util.ArrayList;
 import java.util.List;
-import javax.json.bind.annotation.JsonbDateFormat;
+import jakarta.json.bind.annotation.JsonbDateFormat;
 
 import org.eclipse.microprofile.graphql.NonNull;
 

--- a/tck/src/main/java/org/eclipse/microprofile/graphql/tck/dynamic/DeployableUnit.java
+++ b/tck/src/main/java/org/eclipse/microprofile/graphql/tck/dynamic/DeployableUnit.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ * Copyright (c) 2020, 2021 Contributors to the Eclipse Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,6 +23,8 @@ import org.eclipse.microprofile.graphql.tck.apps.basic.api.ScalarTestApi;
 import org.eclipse.microprofile.graphql.tck.apps.superhero.api.HeroFinder;
 import org.eclipse.microprofile.graphql.tck.apps.superhero.db.HeroDatabase;
 import org.eclipse.microprofile.graphql.tck.apps.superhero.model.SuperHero;
+import org.eclipse.microprofile.graphql.tck.dynamic.execution.GraphQLTestDataProvider;
+import org.eclipse.microprofile.graphql.tck.dynamic.schema.SchemaTestDataProvider;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
@@ -46,7 +48,9 @@ public class DeployableUnit {
                 .addPackage(HeroFinder.class.getPackage())
                 .addPackage(HeroDatabase.class.getPackage())
                 .addPackage(SuperHero.class.getPackage())
-                .addPackage(ScalarTestApi.class.getPackage());
+                .addPackage(ScalarTestApi.class.getPackage())
+                .addPackage(SchemaTestDataProvider.class.getPackage())
+                .addPackage(GraphQLTestDataProvider.class.getPackage());
     }
     
     private static String getPropertyAsString() throws IOException {    

--- a/tck/src/main/java/org/eclipse/microprofile/graphql/tck/dynamic/ExecutionDynamicTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/graphql/tck/dynamic/ExecutionDynamicTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Contributors to the Eclipse Foundation
+ * Copyright 2020, 2021 Contributors to the Eclipse Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,11 +36,11 @@ import java.util.Map;
 import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import javax.json.Json;
-import javax.json.JsonArray;
-import javax.json.JsonObject;
-import javax.json.JsonPatchBuilder;
-import javax.json.JsonReader;
+import jakarta.json.Json;
+import jakarta.json.JsonArray;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonPatchBuilder;
+import jakarta.json.JsonReader;
 import org.jboss.shrinkwrap.api.Archive;
 import org.json.JSONException;
 import org.skyscreamer.jsonassert.JSONAssert;

--- a/tck/src/main/java/org/eclipse/microprofile/graphql/tck/dynamic/execution/GraphQLTestDataProvider.java
+++ b/tck/src/main/java/org/eclipse/microprofile/graphql/tck/dynamic/execution/GraphQLTestDataProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Contributors to the Eclipse Foundation
+ * Copyright 2020, 2021 Contributors to the Eclipse Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,9 +36,9 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import javax.json.Json;
-import javax.json.JsonObject;
-import javax.json.JsonReader;
+import jakarta.json.Json;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonReader;
 import org.eclipse.microprofile.graphql.tck.dynamic.DynamicPaths;
 import org.testng.annotations.DataProvider;
 

--- a/tck/src/main/java/org/eclipse/microprofile/graphql/tck/dynamic/execution/PrintUtil.java
+++ b/tck/src/main/java/org/eclipse/microprofile/graphql/tck/dynamic/execution/PrintUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Contributors to the Eclipse Foundation
+ * Copyright 2020, 2021 Contributors to the Eclipse Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,12 +29,12 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import javax.json.Json;
-import javax.json.JsonObject;
-import javax.json.JsonReader;
-import javax.json.JsonWriter;
-import javax.json.JsonWriterFactory;
-import javax.json.stream.JsonGenerator;
+import jakarta.json.Json;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonReader;
+import jakarta.json.JsonWriter;
+import jakarta.json.JsonWriterFactory;
+import jakarta.json.stream.JsonGenerator;
 
 /**
  * Print the Test data to output

--- a/tck/src/main/java/org/eclipse/microprofile/graphql/tck/dynamic/execution/TestData.java
+++ b/tck/src/main/java/org/eclipse/microprofile/graphql/tck/dynamic/execution/TestData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Contributors to the Eclipse Foundation
+ * Copyright 2020, 2021 Contributors to the Eclipse Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@ import java.util.HashSet;
 import java.util.Objects;
 import java.util.Properties;
 import java.util.Set;
-import javax.json.JsonObject;
+import jakarta.json.JsonObject;
 
 /**
  * Simple Holder for Test Data sets


### PR DESCRIPTION
This PR updates the dependencies to EE 9.1 (primarily CDI 3.0, and JSON-B/P 2.0) for the spec, api, and tck.  It changes the code to use `jakarta.*` instead of `javax.*` packages. It also makes a tweak to include additional TCK packages in the deployed app.

I tested this in Open Liberty using a transformed version of SmallRye GraphQL.  It passed all tests except for schema tests 66 and 67.  The version of SmallRye GraphQL we are using may be too old - but passing the other tests gives me confidence that the changes in this PR are good.  I plan to update SmallRye in Open Liberty as soon as our internal dependency tools are back up again.

Fixes #386. 

Note that the target branch for this PR is `EE9`.  `EE9` is based off of the `1.1.x_service` branch.  The plan is to build the 2.0 release off of the EE9 branch and then up-merge it to `master` for future (2.1 / 3.0) releases.