### PR TITLE
Update CI to build with JDK 17 and 21

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,17 +8,18 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [8, 11]
+        java: [17, 21]
     name: build with jdk ${{matrix.java}}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         name: checkout
 
-      - uses: actions/setup-java@v1
+      - uses: actions/setup-java@v4
         name: set up jdk ${{matrix.java}}
         with:
           java-version: ${{matrix.java}}
+          distribution: 'temurin'
 
       - name: build with maven
         run: mvn -B verify javadoc:javadoc --file pom.xml


### PR DESCRIPTION
The CI workflow was still building against JDK 8 and 11, which is out of step with the rest of the MicroProfile ecosystem. Other specs (Config, Health, Fault Tolerance, REST Client) have all moved to JDK 17 and 21.

This also updates the GitHub Actions to current versions (checkout v4, setup-java v4 with Temurin distribution).