### PR TITLE
Change TestData.variables from JsonObject to Map

### DIFF
--- a/tck/src/main/java/org/eclipse/microprofile/graphql/tck/dynamic/ExecutionDynamicTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/graphql/tck/dynamic/ExecutionDynamicTest.java
@@ -29,6 +29,7 @@ import java.net.URI;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
@@ -252,7 +253,8 @@ public class ExecutionDynamicTest extends Arquillian {
         return sb.toString();
     }
 
-    private HttpResponse postHTTPRequest(String graphQL, JsonObject variables, Map<String, String> httpHeaders) {
+    private HttpResponse postHTTPRequest(String graphQL, Map<String, Object> variables,
+            Map<String, String> httpHeaders) {
         try {
             URL url = new URL(this.uri + PATH);
             HttpURLConnection connection = (HttpURLConnection) url.openConnection();
@@ -304,12 +306,14 @@ public class ExecutionDynamicTest extends Arquillian {
         connection.setReadTimeout(READ_TIMEOUT);
     }
 
-    private JsonObject createRequestBody(String graphQL, JsonObject variables) {
-        // Create the request
+    private JsonObject createRequestBody(String graphQL, Map<String, Object> variables) {
         if (variables == null || variables.isEmpty()) {
-            variables = Json.createObjectBuilder().build();
+            variables = Collections.emptyMap();
         }
-        return Json.createObjectBuilder().add(QUERY, graphQL).add(VARIABLES, variables).build();
+        return Json.createObjectBuilder()
+                .add(QUERY, graphQL)
+                .add(VARIABLES, Json.createObjectBuilder(variables))
+                .build();
     }
 
     private void postRequest(HttpURLConnection connection, JsonObject body) throws IOException {

--- a/tck/src/main/java/org/eclipse/microprofile/graphql/tck/dynamic/execution/GraphQLTestDataProvider.java
+++ b/tck/src/main/java/org/eclipse/microprofile/graphql/tck/dynamic/execution/GraphQLTestDataProvider.java
@@ -28,8 +28,10 @@ import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 import java.util.logging.Level;
@@ -41,8 +43,12 @@ import org.eclipse.microprofile.graphql.tck.dynamic.DynamicPaths;
 import org.testng.annotations.DataProvider;
 
 import jakarta.json.Json;
+import jakarta.json.JsonArray;
+import jakarta.json.JsonNumber;
 import jakarta.json.JsonObject;
 import jakarta.json.JsonReader;
+import jakarta.json.JsonString;
+import jakarta.json.JsonValue;
 
 /**
  * Provide test data for GraphQL Endpoint from the implementation's /src/test/resources/tests directory and the
@@ -165,7 +171,7 @@ public class GraphQLTestDataProvider {
                             }
                             case "variables.json" : {
                                 String content = getFileContent(file);
-                                testData.setVariables(toJsonObject(content));
+                                testData.setVariables(toVariablesMap(content));
                                 break;
                             }
                             case "test.properties" : {
@@ -233,12 +239,47 @@ public class GraphQLTestDataProvider {
         return directories;
     }
 
-    private static JsonObject toJsonObject(String jsonString) {
+    private static Map<String, Object> toVariablesMap(String jsonString) {
         if (jsonString == null || jsonString.isEmpty()) {
             return null;
         }
         try (JsonReader jsonReader = Json.createReader(new StringReader(jsonString))) {
-            return jsonReader.readObject();
+            return jsonObjectToMap(jsonReader.readObject());
+        }
+    }
+
+    private static Map<String, Object> jsonObjectToMap(JsonObject obj) {
+        Map<String, Object> map = new HashMap<>();
+        for (Map.Entry<String, JsonValue> entry : obj.entrySet()) {
+            map.put(entry.getKey(), jsonValueToObject(entry.getValue()));
+        }
+        return map;
+    }
+
+    private static Object jsonValueToObject(JsonValue value) {
+        switch (value.getValueType()) {
+            case STRING :
+                return ((JsonString) value).getString();
+            case NUMBER :
+                JsonNumber number = (JsonNumber) value;
+                return number.isIntegral() ? number.longValue() : number.doubleValue();
+            case TRUE :
+                return Boolean.TRUE;
+            case FALSE :
+                return Boolean.FALSE;
+            case NULL :
+                return null;
+            case OBJECT :
+                return jsonObjectToMap(value.asJsonObject());
+            case ARRAY :
+                JsonArray arr = value.asJsonArray();
+                List<Object> list = new ArrayList<>();
+                for (JsonValue item : arr) {
+                    list.add(jsonValueToObject(item));
+                }
+                return list;
+            default :
+                return value.toString();
         }
     }
 

--- a/tck/src/main/java/org/eclipse/microprofile/graphql/tck/dynamic/execution/PrintUtil.java
+++ b/tck/src/main/java/org/eclipse/microprofile/graphql/tck/dynamic/execution/PrintUtil.java
@@ -75,7 +75,9 @@ public class PrintUtil {
             }
 
             sw.write("\n\n");
-            sw.write("variables input = " + prettyJson(testData.getVariables()));
+            sw.write("variables input = " + prettyJson(testData.getVariables() != null
+                    ? Json.createObjectBuilder(testData.getVariables()).build()
+                    : null));
             sw.write("\n\n");
             sw.write("http headers input = " + testData.getHttpHeaders());
             sw.write("\n\n");

--- a/tck/src/main/java/org/eclipse/microprofile/graphql/tck/dynamic/execution/TestData.java
+++ b/tck/src/main/java/org/eclipse/microprofile/graphql/tck/dynamic/execution/TestData.java
@@ -18,11 +18,10 @@
 package org.eclipse.microprofile.graphql.tck.dynamic.execution;
 
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Properties;
 import java.util.Set;
-
-import jakarta.json.JsonObject;
 
 /**
  * Simple Holder for Test Data sets
@@ -34,7 +33,7 @@ public class TestData {
     private Set<String> input;
     private Properties httpHeaders;
     private Set<String> output;
-    private JsonObject variables;
+    private Map<String, Object> variables;
     private String prepare;
     private String cleanup;
     private Properties properties;
@@ -53,7 +52,7 @@ public class TestData {
             Set<String> input,
             Properties httpHeaders,
             Set<String> output,
-            JsonObject variables,
+            Map<String, Object> variables,
             String prepare,
             String cleanup,
             Properties properties) {
@@ -84,7 +83,7 @@ public class TestData {
         return output;
     }
 
-    public JsonObject getVariables() {
+    public Map<String, Object> getVariables() {
         return variables;
     }
 
@@ -124,7 +123,7 @@ public class TestData {
         this.output.add(output);
     }
 
-    public void setVariables(JsonObject variables) {
+    public void setVariables(Map<String, Object> variables) {
         this.variables = variables;
     }
 


### PR DESCRIPTION
Decouple the TCK's `TestData` from `jakarta.json.JsonObject` by using a plain `Map<String, Object>` for GraphQL variables. This lets implementations consume variables without depending on JSON-P, since `Map` is the natural Java representation and what graphql-java's `ExecutionInput.variables()` expects anyway.

The JSON-P parsing stays in `GraphQLTestDataProvider` (which already needs JSON-P for response validation) and converts to `Map` at the boundary. `ExecutionDynamicTest` converts back to `JsonObject` only when building the HTTP request body via `Json.createObjectBuilder(variables)`.